### PR TITLE
Refactor service navigation and assets

### DIFF
--- a/src/components/NavCtas.astro
+++ b/src/components/NavCtas.astro
@@ -1,0 +1,28 @@
+---
+import type { Locale } from '../data/navigation';
+
+interface Props {
+  lang?: Locale;
+}
+
+const { lang = 'cs' }: Props = Astro.props;
+
+const ctas = {
+  cs: {
+    href: '/#contact-section',
+    label: 'Domluvit konzultaci',
+  },
+  en: {
+    href: '/en/#contact-section',
+    label: 'Book a consultation',
+  },
+} as const satisfies Record<Locale, { href: string; label: string }>;
+
+const cta = ctas[lang];
+---
+<Fragment slot="nav-desktop-cta">
+  <a class="theme_btn" href={cta.href}>{cta.label}</a>
+</Fragment>
+<Fragment slot="nav-mobile-cta">
+  <a class="theme_btn w-100 text-center" href={cta.href}>{cta.label}</a>
+</Fragment>

--- a/src/data/serviceAlternates.ts
+++ b/src/data/serviceAlternates.ts
@@ -1,0 +1,54 @@
+import type { Locale } from './navigation';
+import type { AlternateLink } from '../utils/seo';
+
+const serviceSlugPairs = [
+  { cs: 'seo-audit', en: 'seo-audit' },
+  { cs: 'navrh-struktury-webu', en: 'website-structure' },
+  { cs: 'seo-redesign-webu', en: 'seo-redesign' },
+  { cs: 'analyza-klicovych-slov', en: 'keyword-analysis' },
+  { cs: 'technicky-audit-webu', en: 'technical-seo-audit' },
+  { cs: 'online-pr-a-linkbuilding', en: 'online-pr-linkbuilding' },
+  { cs: 'analyza-konkurence', en: 'competitor-analysis' },
+  { cs: 'kontinualni-seo', en: 'continuous-seo' },
+  { cs: 'seo-skoleni', en: 'seo-workshops' },
+  { cs: 'marketingova-strategie', en: 'marketing-strategy' },
+  { cs: 'obsahova-strategie', en: 'content-strategy' },
+  { cs: 'copywritting', en: 'copywriting' },
+  { cs: 'podpora-pro-startupy', en: 'support-for-startups' },
+  { cs: 'skoleni-marketingu', en: 'marketing-workshops' },
+  { cs: 'geo-optimalizace-llms', en: 'llm-optimization-geo' },
+  { cs: 'konzultace-ai', en: 'ai-consulting' },
+  { cs: 'ai-agenti-a-automatizace', en: 'ai-agents-and-automation' },
+  { cs: 'skoleni-ai', en: 'ai-workshop' },
+] as const satisfies ReadonlyArray<{ cs: string; en: string }>;
+
+type ServiceSlugPair = (typeof serviceSlugPairs)[number];
+
+const serviceSlugMap: Record<Locale, Map<string, ServiceSlugPair>> = {
+  cs: new Map(serviceSlugPairs.map((pair) => [pair.cs, pair])),
+  en: new Map(serviceSlugPairs.map((pair) => [pair.en, pair])),
+};
+
+const buildHref = (locale: Locale, slug: string) =>
+  locale === 'cs'
+    ? `https://bangho.cz/sluzby/${slug}.html`
+    : `https://bangho.cz/en/services/${slug}.html`;
+
+export const getServiceAlternates = (slug: string, lang: Locale): AlternateLink[] => {
+  const pair = serviceSlugMap[lang].get(slug);
+
+  if (!pair) {
+    return [];
+  }
+
+  const csHref = buildHref('cs', pair.cs);
+  const enHref = buildHref('en', pair.en);
+
+  return [
+    { href: csHref, hreflang: 'cs' },
+    { href: enHref, hreflang: 'en' },
+    { href: enHref, hreflang: 'x-default' },
+  ];
+};
+
+export type ServiceSlug = ServiceSlugPair[keyof ServiceSlugPair];

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -338,7 +338,7 @@ const seo: SeoInput = {
                     class="hero-image-box d-md-none wow fadeInRight"
                     data-wow-delay="0.3s"
                   >
-                    <img src="../assets/img/hero/me.webp" alt="" />
+                    <img src="/assets/img/hero/me.webp" alt="" />
                   </div>
                   <p class="lead wow fadeInLeft" data-wow-delay="0.3s">
                     I design data-driven SEO strategies that deliver results even
@@ -383,7 +383,7 @@ const seo: SeoInput = {
                   style="position: relative; width: 100%"
                 >
                   <img
-                    src="../assets/img/hero/me.webp"
+                    src="/assets/img/hero/me.webp"
                     alt=""
                     style="
                       width: 100%;
@@ -584,7 +584,7 @@ const seo: SeoInput = {
 
                               <div class="portfolio-item">
                                   <div class="image-box">
-                                      <img src="../assets/img/portfolio/O2-Logo.svg" alt="" />
+                                      <img src="/assets/img/portfolio/O2-Logo.svg" alt="" />
                                   </div>
                                   <div class="content-box">
                                       <h3 class="portfolio-title">O2 Czech Republic</h3>
@@ -595,7 +595,7 @@ const seo: SeoInput = {
                               </div>
                               <div class="portfolio-item">
                                   <div class="image-box">
-                                      <img src="../assets/img/portfolio/Gen_logo.svg" alt="" />
+                                      <img src="/assets/img/portfolio/Gen_logo.svg" alt="" />
                                   </div>
                                   <div class="content-box">
                                       <h3 class="portfolio-title">Gen Digital Inc.</h3>
@@ -617,7 +617,7 @@ const seo: SeoInput = {
                               <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="../assets/img/portfolio/angry.svg" alt="" />
+                                          <img src="/assets/img/portfolio/angry.svg" alt="" />
                                       </div>
                                       <div class="number">Angry Beards</div>
                                   </div>
@@ -625,7 +625,7 @@ const seo: SeoInput = {
                               <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="../assets/img/portfolio/srovname.svg" alt="" />
+                                          <img src="/assets/img/portfolio/srovname.svg" alt="" />
                                       </div>
                                       <div class="number">Srovnáme</div>
                                   </div>
@@ -633,7 +633,7 @@ const seo: SeoInput = {
                               <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="../assets/img/portfolio/avast.svg" alt="" />
+                                          <img src="/assets/img/portfolio/avast.svg" alt="" />
                                       </div>
                                       <div class="number">Avast</div>
                                   </div>
@@ -641,7 +641,7 @@ const seo: SeoInput = {
                               <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="../assets/img/portfolio/norton.svg" alt="" />
+                                          <img src="/assets/img/portfolio/norton.svg" alt="" />
                                       </div>
                                       <div class="number">Norton</div>
                                   </div>
@@ -649,7 +649,7 @@ const seo: SeoInput = {
                               <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="../assets/img/portfolio/cockyna.svg" alt="" />
+                                          <img src="/assets/img/portfolio/cockyna.svg" alt="" />
                                       </div>
                                       <div class="number">Čočkýna</div>
                                   </div>
@@ -695,16 +695,16 @@ const seo: SeoInput = {
 
                   <div class="portfolio_gallery owl-carousel">
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/o2_2.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/o2_2.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/o2_3.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/o2_3.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/o2_4.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/o2_4.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/o2_5.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/o2_5.png" alt="" />
                       </div>
                   </div>
 
@@ -792,16 +792,16 @@ const seo: SeoInput = {
 
                   <div class="portfolio_gallery owl-carousel">
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/sofa_2.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/sofa_2.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/sofa_3.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/sofa_3.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/sofa_4.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/sofa_4.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/sofa_5.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/sofa_5.png" alt="" />
                       </div>
                   </div>
 
@@ -904,13 +904,13 @@ const seo: SeoInput = {
 
                   <div class="portfolio_gallery owl-carousel">
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/avast.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/avast.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/norton.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/norton.png" alt="" />
                       </div>
                       <div class="gallery_item">
-                          <img src="../assets/img/portfolio-gallery/lifelock.png" alt="" />
+                          <img src="/assets/img/portfolio-gallery/lifelock.png" alt="" />
                       </div>
                   </div>
 
@@ -1054,7 +1054,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/scf.svg" alt="" />
+                        <img src="/assets/img/icons/scf.svg" alt="" />
                       </div>
                       <div class="number">Screaming Frog</div>
                     </div>
@@ -1062,7 +1062,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/Ahrefs.svg" alt="" />
+                        <img src="/assets/img/icons/Ahrefs.svg" alt="" />
                       </div>
                       <div class="number">Ahrefs<br /></div>
                     </div>
@@ -1071,7 +1071,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/gsc.svg" alt="" />
+                        <img src="/assets/img/icons/gsc.svg" alt="" />
                       </div>
                       <div class="number">Search Console</div>
                     </div>
@@ -1079,7 +1079,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/ga.svg" alt="" />
+                        <img src="/assets/img/icons/ga.svg" alt="" />
                       </div>
                       <div class="number">Google Analytics</div>
                     </div>
@@ -1087,7 +1087,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/looker.svg" alt="" />
+                        <img src="/assets/img/icons/looker.svg" alt="" />
                       </div>
                       <div class="number">Data Analytics</div>
                     </div>
@@ -1095,7 +1095,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/wp.svg" alt="" />
+                        <img src="/assets/img/icons/wp.svg" alt="" />
                       </div>
                       <div class="number">CMS<br />Systems</div>
                     </div>
@@ -1103,7 +1103,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/html.svg" alt="" />
+                        <img src="/assets/img/icons/html.svg" alt="" />
                       </div>
                       <div class="number">Web &<br />Development</div>
                     </div>
@@ -1111,7 +1111,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/chatgpt.svg" alt="" />
+                        <img src="/assets/img/icons/chatgpt.svg" alt="" />
                       </div>
                       <div class="number">AI Tools<br />& LLMs</div>
                     </div>
@@ -1119,7 +1119,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/n8n.png" alt="" />
+                        <img src="/assets/img/icons/n8n.png" alt="" />
                       </div>
                       <div class="number">AI Agents & <br />Automation</div>
                     </div>
@@ -1127,7 +1127,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="../assets/img/icons/jira.svg" alt="" />
+                        <img src="/assets/img/icons/jira.svg" alt="" />
                       </div>
                       <div class="number">Project Management</div>
                     </div>
@@ -1179,7 +1179,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="../assets/img/testimonials/user/kejval.jpg"
+                            src="/assets/img/testimonials/user/kejval.jpg"
                             alt=""
                           />
                         </div>
@@ -1272,7 +1272,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="../assets/img/testimonials/user/zatkovic.webp"
+                            src="/assets/img/testimonials/user/zatkovic.webp"
                             alt=""
                           />
                         </div>
@@ -1362,7 +1362,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="../assets/img/testimonials/user/vlcek.jpg"
+                            src="/assets/img/testimonials/user/vlcek.jpg"
                             alt=""
                           />
                         </div>
@@ -1453,7 +1453,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="../assets/img/testimonials/user/kapic.jpg"
+                            src="/assets/img/testimonials/user/kapic.jpg"
                             alt=""
                           />
                         </div>
@@ -1546,7 +1546,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="../assets/img/testimonials/user/architekti.jpg"
+                            src="/assets/img/testimonials/user/architekti.jpg"
                             alt=""
                           />
                         </div>
@@ -1801,30 +1801,30 @@ const seo: SeoInput = {
 
 
       <!-- jQuery -->
-      <script src="../assets/js/jquery.min.js"></script>
+      <script src="/assets/js/jquery.min.js" is:inline></script>
 
       <!-- jQuery pluginy -->
-      <script src="../assets/js/jquery.nice-select.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/owl.carousel.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/odometer.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/backToTop.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/appear.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/gsap.min.js"></script>
-      <script src="../assets/js/one-page-nav.js"></script>
-      <script src="../assets/js/lightcase.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
+      <script src="/assets/js/jquery.nice-select.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/owl.carousel.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/odometer.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/backToTop.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/appear.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/gsap.min.js" is:inline></script>
+      <script src="/assets/js/one-page-nav.js" is:inline></script>
+      <script src="/assets/js/lightcase.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
       <!-- AOS knihovna pro animace on scroll -->
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
       <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
@@ -1832,13 +1832,13 @@ const seo: SeoInput = {
       <!-- Bootstrap a další knihovny -->
       <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" crossorigin="anonymous"></script>
       <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" crossorigin="anonymous"></script>
-      <script src="../assets/js/bootstrap.bundle.min.js"></script>
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
+      <script src="/assets/js/bootstrap.bundle.min.js" is:inline></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
 
       <!-- Ostatní pluginy -->
       <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.9/validator.min.js" crossorigin="anonymous"></script>
-      <script src="../assets/js/plugins.js"></script>
-      <script src="../assets/js/footer-animations.js"></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
+      <script src="/assets/js/footer-animations.js" is:inline></script>
 
       <!-- Inicializace AOS -->
       <script>
@@ -1848,8 +1848,8 @@ const seo: SeoInput = {
       </script>
 
       <!-- Vlastní skripty až nakonec -->
-      <script src="../assets/js/main.js"></script>
-      <script src="../sluzby/js/main.js"></script>
+      <script src="/assets/js/main.js" is:inline></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
       <!-- reCAPTCHA v3 -->
       <script src="https://www.google.com/recaptcha/api.js?render=6LeLuxwrAAAAACS4SwjIa4pBGqOty0K_qNOrtHtI"></script>
@@ -1872,7 +1872,7 @@ const seo: SeoInput = {
       </script>
 
       <!-- ScrollUp button -->
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
       <script>
           $(function() {
               var iconHtml = '<i class="bi bi-arrow-up"></i>';

--- a/src/pages/en/services/ai-agents-and-automation.astro
+++ b/src/pages/en/services/ai-agents-and-automation.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'AI Agents & Automation | Secure, open-source solutions',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/ai-agents-and-automation.html',
   ogTitle: 'AI Agents & Automation',
   ogDescription: 'Tailored solutions with compliance and control.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/ai-agenti-a-automatizace.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/ai-agents-and-automation.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/ai-agents-and-automation.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('ai-agents-and-automation', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="ai-agents-and-automation.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/ai-agenti-a-automatizace.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -697,7 +547,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -834,28 +684,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/ai-consulting.astro
+++ b/src/pages/en/services/ai-consulting.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'AI Consulting | From concept to implementation roadmap',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/ai-consulting.html',
   ogTitle: 'AI Consulting',
   ogDescription: 'Explore how AI can optimize your business.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/konzultace-ai.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/ai-consulting.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/ai-consulting.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('ai-consulting', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="ai-consulting.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/konzultace-ai.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -699,7 +549,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -836,28 +686,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/ai-workshop.astro
+++ b/src/pages/en/services/ai-workshop.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'AI Training | From fundamentals to advanced applications',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/ai-workshop.html',
   ogTitle: 'Practical AI Training',
   ogDescription: 'From fundamentals to local AI solutions.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/skoleni-ai.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/ai-workshop.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/ai-workshop.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('ai-workshop', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="ai-workshop.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/skoleni-ai.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -702,7 +552,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -839,28 +689,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/competitor-analysis.astro
+++ b/src/pages/en/services/competitor-analysis.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Competitor Analysis (Gap Analysis) | Identify growth opportunities',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/competitor-analysis.html',
   ogTitle: 'Competitor Analysis (Gap Analysis)',
   ogDescription: 'Identify gaps and turn them into growth.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/analyza-konkurence.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/competitor-analysis.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/competitor-analysis.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('competitor-analysis', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="competitor-analysis.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/analyza-konkurence.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -741,7 +591,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -878,28 +728,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/content-strategy.astro
+++ b/src/pages/en/services/content-strategy.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Content Strategy | Systematic approach to content creation',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/content-strategy.html',
   ogTitle: 'Content Strategy',
   ogDescription: 'Framework for systematic content creation.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/obsahova-strategie.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/content-strategy.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/content-strategy.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('content-strategy', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="content-strategy.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/obsahova-strategie.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -715,7 +565,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -852,28 +702,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/continuous-seo.astro
+++ b/src/pages/en/services/continuous-seo.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Continuous SEO | Monthly optimization and reporting',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/continuous-seo.html',
   ogTitle: 'Ongoing SEO Services',
   ogDescription: 'Monthly SEO optimization and reporting.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/kontinualni-seo.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/continuous-seo.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/continuous-seo.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('continuous-seo', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="continuous-seo.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/kontinualni-seo.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -736,7 +586,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -873,28 +723,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/copywriting.astro
+++ b/src/pages/en/services/copywriting.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Copywriting | Professional texts for all channels',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/copywriting.html',
   ogTitle: 'Copywriting Services',
   ogDescription: 'Professional copywriting services for websites, blogs, and marketing materials.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/copywriting.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/copywriting.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/copywriting.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('copywriting', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="copywriting.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/copywritting.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -717,7 +567,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -854,28 +704,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/keyword-analysis.astro
+++ b/src/pages/en/services/keyword-analysis.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Keyword Analysis | Data-driven insights for SEO and PPC',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/keyword-analysis.html',
   ogTitle: 'Keyword Analysis',
   ogDescription: 'Deliverable includes structured keywords, priorities, and trends.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/analyza-klicovych-slov.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/keyword-analysis.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/keyword-analysis.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('keyword-analysis', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="keyword-analysis.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/analyza-klicovych-slov.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -760,7 +610,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -897,28 +747,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/llm-optimization-geo.astro
+++ b/src/pages/en/services/llm-optimization-geo.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Optimization for LLMs | Prepare your site for AI visibility',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/llm-optimization-geo.html',
   ogTitle: 'Optimization for LLMs (GEO)',
   ogDescription: 'Ensure your site is ready for AI-driven search.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/geo-optimalizace-llms.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/llm-optimization-geo.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/llm-optimization-geo.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('llm-optimization-geo', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="llm-optimization-geo.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/geo-optimalizace-llms.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -699,7 +549,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -836,28 +686,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/marketing-strategy.astro
+++ b/src/pages/en/services/marketing-strategy.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Marketing Strategy | Complete playbook for brand growth',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/marketing-strategy.html',
   ogTitle: 'Marketing Strategy',
   ogDescription: 'The deliverable is a unified playbook for driving growth.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/marketingova-strategie.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/marketing-strategy.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/marketing-strategy.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('marketing-strategy', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="marketing-strategy.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/marketingova-strategie.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -692,7 +542,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -829,28 +679,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/marketing-workshops.astro
+++ b/src/pages/en/services/marketing-workshops.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Marketing Training | Strategy, channels & measurement',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/marketing-workshops.html',
   ogTitle: 'Marketing Training',
   ogDescription: 'Practical training with strategy and tools.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/skoleni-marketingu.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/marketing-workshops.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/marketing-workshops.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('marketing-workshops', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="marketing-workshops.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/skoleni-marketingu.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -720,7 +570,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -857,28 +707,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/online-pr-linkbuilding.astro
+++ b/src/pages/en/services/online-pr-linkbuilding.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Online PR & Link Building | Build authority with quality backlinks',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/online-pr-linkbuilding.html',
   ogTitle: 'Online PR & Link Building',
   ogDescription: 'Build authority with high-quality backlinks.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/online-pr-a-linkbuilding.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/online-pr-linkbuilding.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/online-pr-linkbuilding.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('online-pr-linkbuilding', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="online-pr-linkbuilding.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/online-pr-a-linkbuilding.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -740,7 +590,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -877,28 +727,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/seo-audit.astro
+++ b/src/pages/en/services/seo-audit.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'SEO Audit | Technical, on-page, off-page & competitor review',
@@ -9,15 +11,12 @@ const seo: SeoInput = {
   ogTitle: 'SEO Audit',
   ogDescription: 'Detailed audit with competitor analysis.',
   ogUrl: 'https://bangho.cz/en/services/seo-audit.html',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/seo-audit.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/seo-audit.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/seo-audit.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('seo-audit', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="seo-audit.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/seo-audit.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -755,7 +605,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -892,28 +742,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/seo-redesign.astro
+++ b/src/pages/en/services/seo-redesign.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Website Redesign SEO | Structure, redirects, and performance',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/seo-redesign.html',
   ogTitle: 'Redesign with full SEO oversight.',
   ogDescription: 'Roadmap, audits, and direct cooperation with developers.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/seo-redesign-webu.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/seo-redesign.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/seo-redesign.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('seo-redesign', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="seo-redesign.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/seo-redesign-webu.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -747,7 +597,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -884,28 +734,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/seo-workshops.astro
+++ b/src/pages/en/services/seo-workshops.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'SEO Training | Learn how to optimize and grow your website',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/seo-workshops.html',
   ogTitle: 'Learn SEO',
   ogDescription: 'Tailored SEO training with practical examples.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/seo-skoleni.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/seo-workshops.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/seo-workshops.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('seo-workshops', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="seo-workshops.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/seo-skoleni.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -745,7 +595,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -882,28 +732,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/support-for-startups.astro
+++ b/src/pages/en/services/support-for-startups.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Marketing Support for Startups – flexible consulting',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/support-for-startups.html',
   ogTitle: 'Startup Marketing Support',
   ogDescription: 'Marketing support adapted to your resources.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/podpora-pro-startupy.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/support-for-startups.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/support-for-startups.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('support-for-startups', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,156 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="support-for-startups.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/podpora-pro-startupy.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -689,7 +539,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -826,28 +676,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/technical-seo-audit.astro
+++ b/src/pages/en/services/technical-seo-audit.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Technical SEO Audit | In-depth website health analysis',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/technical-seo-audit.html',
   ogTitle: 'SEO Technical Audit',
   ogDescription: 'In-depth analysis of technical site health.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/technicky-seo-audit.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/technical-seo-audit.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/technical-seo-audit.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('technical-seo-audit', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="technical-seo-audit.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/technicky-audit-webu.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -751,7 +601,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -888,28 +738,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/en/services/website-structure.astro
+++ b/src/pages/en/services/website-structure.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../../layouts/Base.astro';
+import NavCtas from '../../../components/NavCtas.astro';
 import type { SeoInput } from '../../../utils/seo';
+import { getServiceAlternates } from '../../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Website Structure | Hierarchy, content pillars, and metadata',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/en/services/website-structure.html',
   ogTitle: 'Website Structure and hierarchy',
   ogDescription: 'The service delivers a complete website structure including categories, URLs, and metadata.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/navrh-struktury-webu.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/website-structure.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/website-structure.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('website-structure', 'en'),
 };
 ---
 
 <Base lang="en" seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="en" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,156 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Services</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="website-structure.html">Website Structure</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign.html">Website Redesign</a>
-                  </li>
-                  <li>
-                    <a href="keyword-analysis.html">Keyword Analysis</a>
-                  </li>
-                  <li>
-                    <a href="technical-seo-audit.html">Technical SEO Audit</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-linkbuilding.html">Online PR</a>
-                  </li>
-                  <li>
-                    <a href="competitor-analysis.html">Competitor analyses</a>
-                  </li>
-                  <li>
-                    <a href="continuous-seo.html">Continuous SEO</a>
-                  </li>
-                  <li>
-                    <a href="seo-workshops.html">SEO Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketing-strategy.html">Marketing Strategy</a>
-                  </li>
-                  <li>
-                    <a href="content-strategy.html">Content Strategy</a>
-                  </li>
-                  <li><a href="copywriting.html">Copywriting</a></li>
-                  <li>
-                    <a href="support-for-startups.html">Support for Startups</a>
-                  </li>
-                  <li>
-                    <a href="marketing-workshops.html">Marketing Workshops</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI for Businesses</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="llm-optimization-geo.html">LLM Optimization GEO</a>
-                  </li>
-                  <li>
-                    <a href="ai-consulting.html">AI Consulting</a>
-                  </li>
-                  <li>
-                    <a href="ai-agents-and-automation.html"
-                      >AI Agents and Automation</a
-                    >
-                  </li>
-                  <li><a href="ai-workshop.html">AI Workshop</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">References</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../../assets/img/flags/gb.svg"
-                  alt="English"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                EN
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="website-structure.html"
-                    hreflang="en"
-                    ><img
-                      src="../../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../../sluzby/navrh-struktury-webu.html"
-                    hreflang="cs"
-                    ><img
-                      src="../../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -736,7 +586,7 @@ const seo: SeoInput = {
                         step.
                       </p>
                       <form
-                        action="../../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -873,28 +723,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../../assets/js/vendor/popper.min.js"></script>
-      <script src="../../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../../assets/js/slick.min.js"></script>
-      <script src="../../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../../assets/js/metisMenu.min.js"></script>
-      <script src="../../assets/js/wow.min.js"></script>
-      <script src="../../assets/js/aos.js"></script>
-      <script src="../../assets/js/jquery.counterup.min.js"></script>
-      <script src="../../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../../assets/js/tilt.jquery.min.js"></script>
-      <script src="../../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../../assets/js/jquery-ui.js"></script>
-      <script src="../../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="../../sluzby/js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -372,7 +372,7 @@ const seo: SeoInput = {
                     class="hero-image-box d-md-none wow fadeInRight"
                     data-wow-delay="0.3s"
                   >
-                    <img src="assets/img/hero/me.webp" alt="" />
+                    <img src="/assets/img/hero/me.webp" alt="" />
                   </div>
                   <p class="lead wow fadeInLeft" data-wow-delay="0.3s">
                     Navrhuji datově podložené SEO strategie, které přinášejí
@@ -417,7 +417,7 @@ const seo: SeoInput = {
                   style="position: relative; width: 100%"
                 >
                   <img
-                    src="assets/img/hero/me.webp"
+                    src="/assets/img/hero/me.webp"
                     alt=""
                     style="
                       width: 100%;
@@ -692,7 +692,7 @@ const seo: SeoInput = {
 
                   <div class="portfolio-item">
                     <div class="image-box">
-                      <img src="assets/img/portfolio/O2-Logo.svg" alt="" />
+                      <img src="/assets/img/portfolio/O2-Logo.svg" alt="" />
                     </div>
                     <div class="content-box">
                       <h3 class="portfolio-title">O2 Czech Republic</h3>
@@ -706,7 +706,7 @@ const seo: SeoInput = {
                   </div>
                   <div class="portfolio-item">
                     <div class="image-box">
-                      <img src="assets/img/portfolio/Gen_logo.svg" alt="" />
+                      <img src="/assets/img/portfolio/Gen_logo.svg" alt="" />
                     </div>
                     <div class="content-box">
                       <h3 class="portfolio-title">Gen Digital Inc.</h3>
@@ -731,7 +731,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/portfolio/angry.svg" alt="" />
+                        <img src="/assets/img/portfolio/angry.svg" alt="" />
                       </div>
                       <div class="number">Angry Beards</div>
                     </div>
@@ -739,7 +739,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/portfolio/srovname.svg" alt="" />
+                        <img src="/assets/img/portfolio/srovname.svg" alt="" />
                       </div>
                       <div class="number">Srovnáme</div>
                     </div>
@@ -747,7 +747,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/portfolio/avast.svg" alt="" />
+                        <img src="/assets/img/portfolio/avast.svg" alt="" />
                       </div>
                       <div class="number">Avast</div>
                     </div>
@@ -755,7 +755,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/portfolio/norton.svg" alt="" />
+                        <img src="/assets/img/portfolio/norton.svg" alt="" />
                       </div>
                       <div class="number">Norton</div>
                     </div>
@@ -763,7 +763,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/portfolio/cockyna.svg" alt="" />
+                        <img src="/assets/img/portfolio/cockyna.svg" alt="" />
                       </div>
                       <div class="number">Čočkýna</div>
                     </div>
@@ -1278,7 +1278,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/scf.svg" alt="" />
+                        <img src="/assets/img/icons/scf.svg" alt="" />
                       </div>
                       <div class="number">Screaming Frog</div>
                     </div>
@@ -1286,7 +1286,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/Ahrefs.svg" alt="" />
+                        <img src="/assets/img/icons/Ahrefs.svg" alt="" />
                       </div>
                       <div class="number">Ahrefs</div>
                     </div>
@@ -1295,7 +1295,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/gsc.svg" alt="" />
+                        <img src="/assets/img/icons/gsc.svg" alt="" />
                       </div>
                       <div class="number">Search Console</div>
                     </div>
@@ -1303,7 +1303,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/ga.svg" alt="" />
+                        <img src="/assets/img/icons/ga.svg" alt="" />
                       </div>
                       <div class="number">Google Analytics</div>
                     </div>
@@ -1311,7 +1311,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/looker.svg" alt="" />
+                        <img src="/assets/img/icons/looker.svg" alt="" />
                       </div>
                       <div class="number">Datová Analytika</div>
                     </div>
@@ -1319,7 +1319,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/wp.svg" alt="" />
+                        <img src="/assets/img/icons/wp.svg" alt="" />
                       </div>
                       <div class="number">CMS<br />Systémy</div>
                     </div>
@@ -1327,7 +1327,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/html.svg" alt="" />
+                        <img src="/assets/img/icons/html.svg" alt="" />
                       </div>
                       <div class="number">Web &<br />Vývoj</div>
                     </div>
@@ -1335,7 +1335,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/chatgpt.svg" alt="" />
+                        <img src="/assets/img/icons/chatgpt.svg" alt="" />
                       </div>
                       <div class="number">AI nástroje<br />& LLMs</div>
                     </div>
@@ -1343,7 +1343,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/n8n.png" alt="" />
+                        <img src="/assets/img/icons/n8n.png" alt="" />
                       </div>
                       <div class="number">AI Agenti & <br />Automatizace</div>
                     </div>
@@ -1351,7 +1351,7 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="assets/img/icons/jira.svg" alt="" />
+                        <img src="/assets/img/icons/jira.svg" alt="" />
                       </div>
                       <div class="number">Projektový Management</div>
                     </div>
@@ -1403,7 +1403,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="assets/img/testimonials/user/kejval.jpg"
+                            src="/assets/img/testimonials/user/kejval.jpg"
                             alt=""
                           />
                         </div>
@@ -1496,7 +1496,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="assets/img/testimonials/user/zatkovic.webp"
+                            src="/assets/img/testimonials/user/zatkovic.webp"
                             alt=""
                           />
                         </div>
@@ -1586,7 +1586,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="assets/img/testimonials/user/vlcek.jpg"
+                            src="/assets/img/testimonials/user/vlcek.jpg"
                             alt=""
                           />
                         </div>
@@ -1676,7 +1676,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="assets/img/testimonials/user/kapic.jpg"
+                            src="/assets/img/testimonials/user/kapic.jpg"
                             alt=""
                           />
                         </div>
@@ -1769,7 +1769,7 @@ const seo: SeoInput = {
                         </div>
                         <div class="image-box">
                           <img
-                            src="assets/img/testimonials/user/architekti.jpg"
+                            src="/assets/img/testimonials/user/architekti.jpg"
                             alt=""
                           />
                         </div>
@@ -2031,30 +2031,30 @@ const seo: SeoInput = {
 
 
       <!-- jQuery -->
-      <script src="assets/js/jquery.min.js"></script>
+      <script src="/assets/js/jquery.min.js" is:inline></script>
 
       <!-- jQuery pluginy -->
-      <script src="assets/js/jquery.nice-select.min.js"></script>
-      <script src="assets/js/metisMenu.min.js"></script>
-      <script src="assets/js/owl.carousel.min.js"></script>
-      <script src="assets/js/isotope.pkgd.min.js"></script>
-      <script src="assets/js/odometer.min.js"></script>
-      <script src="assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="assets/js/jquery.counterup.min.js"></script>
-      <script src="assets/js/jquery.waypoints.min.js"></script>
-      <script src="assets/js/jquery.easypiechart.min.js"></script>
-      <script src="assets/js/jquery-ui.js"></script>
-      <script src="assets/js/jquery.scrollUp.min.js"></script>
-      <script src="assets/js/tilt.jquery.min.js"></script>
-      <script src="assets/js/jquery.supermarquee.min.js"></script>
-      <script src="assets/js/backToTop.js"></script>
-      <script src="assets/js/slick.min.js"></script>
-      <script src="assets/js/appear.min.js"></script>
-      <script src="assets/js/wow.min.js"></script>
-      <script src="assets/js/gsap.min.js"></script>
-      <script src="assets/js/one-page-nav.js"></script>
-      <script src="assets/js/lightcase.js"></script>
-      <script src="assets/js/imagesloaded.pkgd.min.js"></script>
+      <script src="/assets/js/jquery.nice-select.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/owl.carousel.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/odometer.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/backToTop.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/appear.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/gsap.min.js" is:inline></script>
+      <script src="/assets/js/one-page-nav.js" is:inline></script>
+      <script src="/assets/js/lightcase.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
       <!-- AOS knihovna pro animace on scroll -->
       <link
         rel="stylesheet"
@@ -2071,16 +2071,16 @@ const seo: SeoInput = {
         src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
         crossorigin="anonymous"
       ></script>
-      <script src="assets/js/bootstrap.bundle.min.js"></script>
-      <script src="assets/js/vendor/modernizr-3.5.0.min.js"></script>
+      <script src="/assets/js/bootstrap.bundle.min.js" is:inline></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
 
       <!-- Ostatní pluginy -->
       <script
         src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.9/validator.min.js"
         crossorigin="anonymous"
       ></script>
-      <script src="assets/js/plugins.js"></script>
-      <script src="assets/js/footer-animations.js"></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
+      <script src="/assets/js/footer-animations.js" is:inline></script>
 
       <!-- Inicializace AOS -->
       <script>
@@ -2090,8 +2090,8 @@ const seo: SeoInput = {
       </script>
 
       <!-- Vlastní skripty až nakonec -->
-      <script src="assets/js/main.js"></script>
-      <script src="sluzby/js/main.js"></script>
+      <script src="/assets/js/main.js" is:inline></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
       <!-- reCAPTCHA v3 -->
       <script src="https://www.google.com/recaptcha/api.js?render=6LeLuxwrAAAAACS4SwjIa4pBGqOty0K_qNOrtHtI"></script>
@@ -2114,7 +2114,7 @@ const seo: SeoInput = {
       </script>
 
       <!-- ScrollUp button -->
-      <script src="assets/js/jquery.scrollUp.min.js"></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
       <script>
         $(function () {
           var iconHtml = '<i class="bi bi-arrow-up"></i>';

--- a/src/pages/sluzby/ai-agenti-a-automatizace.astro
+++ b/src/pages/sluzby/ai-agenti-a-automatizace.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'AI agenti a automatizace | Návrh a řešení na míru',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/ai-agenti-a-automatizace.html',
   ogTitle: 'AI agenti a automatizace',
   ogDescription: 'Návrh a realizace AI agentů a automatizace procesů s důrazem na bezpečnost.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/ai-agenti-a-automatizace.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/ai-agents-and-automation.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/ai-agents-and-automation.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('ai-agenti-a-automatizace', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,154 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="ai-agenti-a-automatizace.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/ai-agents-and-automation.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -690,7 +542,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -827,28 +679,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/analyza-klicovych-slov.astro
+++ b/src/pages/sluzby/analyza-klicovych-slov.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Analýza klíčových slov | Data pro SEO, PPC i obsah',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/analyza-klicovych-slov.html',
   ogTitle: 'Analýza klíčových slov',
   ogDescription: 'Přehled vyhledávaných dotazů a priorit pro váš web.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/analyza-klicovych-slov.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/keyword-analysis.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/keyword-analysis.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('analyza-klicovych-slov', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="analyza-klicovych-slov.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/keyword-analysis.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -741,7 +595,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -878,28 +732,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/analyza-konkurence.astro
+++ b/src/pages/sluzby/analyza-konkurence.astro
@@ -1,21 +1,20 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'SEO Analýza konkurence | GAP analýza',
   description: 'Gap analýza ukáže, kde má konkurence náskok. Odhalí mezery v obsahu, odkazech i PR a poskytne strategii pro získání výhody',
   canonical: 'https://bangho.cz/sluzby/analyza-konkurence.html',
   ogDescription: 'Získejte strategickou výhodu díky gap analýze.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/analyza-konkurence.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/competitor-analysis.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/competitor-analysis.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('analyza-konkurence', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -382,152 +381,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="analyza-konkurence.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/competitor-analysis.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -733,7 +587,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -870,28 +724,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/copywritting.astro
+++ b/src/pages/sluzby/copywritting.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Copywriting | Texty pro web i další komunikační kanály',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/copywriting.html',
   ogTitle: 'Copywriting na míru',
   ogDescription: 'Kvalitní texty pro váš web i sítě.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/copywriting.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/copywriting.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/copywriting.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('copywritting', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="copywritting.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/copywriting.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -699,7 +553,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -836,28 +690,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/geo-optimalizace-llms.astro
+++ b/src/pages/sluzby/geo-optimalizace-llms.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Optimalizace pro LLMs (GEO) | viditelnost v AI vyhledávání',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/geo-optimalizace-llms.html',
   ogTitle: 'Optimalizace pro LLMs (GEO)',
   ogDescription: 'Optimalizace webu pro LLM a AI vyhledávání.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/geo-optimalizace-llms.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/llm-optimization-geo.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/llm-optimization-geo.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('geo-optimalizace-llms', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="geo-optimalizace-llms.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/llm-optimization-geo.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -695,7 +549,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -832,28 +686,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/kontinualni-seo.astro
+++ b/src/pages/sluzby/kontinualni-seo.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Kontinuální SEO správa | Dlouhodobá spolupráce',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/kontinualni-seo.html',
   ogTitle: 'Kontinuální SEO správa',
   ogDescription: 'Měsíční optimalizace a reporting výsledků.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/kontinualni-seo.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/continuous-seo.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/continuous-seo.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('kontinualni-seo', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="kontinualni-seo.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/continuous-seo.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -732,7 +586,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -869,28 +723,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/konzultace-ai.astro
+++ b/src/pages/sluzby/konzultace-ai.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Konzultace AI | Agenti, integrace a implementace',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/konzultace-ai.html',
   ogTitle: 'Konzultace AI',
   ogDescription: 'Ujasněte si proveditelnost vašeho nápadu, rozsah i očekávání',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/konzultace-ai.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/ai-consulting.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/ai-consulting.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('konzultace-ai', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="konzultace-ai.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/ai-consulting.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -691,7 +545,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -828,28 +682,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/marketingova-strategie.astro
+++ b/src/pages/sluzby/marketingova-strategie.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Marketingová strategie | Segmentace, kanály, KPI, komunikace',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/marketingova-strategie.html',
   ogTitle: 'Marketingová strategie',
   ogDescription: 'Strategický plán pro značku od A do Z.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/marketingova-strategie.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/marketing-strategy.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/marketing-strategy.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('marketingova-strategie', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="marketingova-strategie.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/marketing-strategy.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -681,7 +535,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -818,28 +672,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/navrh-struktury-webu.astro
+++ b/src/pages/sluzby/navrh-struktury-webu.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Návrh struktury webu | Informační architektura webu',
@@ -9,15 +11,12 @@ const seo: SeoInput = {
   ogTitle: 'Návrh struktury webu',
   ogDescription: 'Přehledná struktura stránek s důrazem na SEO.',
   ogUrl: 'https://bangho.cz/sluzby/navrh-struktury-webu.html',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/navrh-struktury-webu.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/website-structure.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/website-structure.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('navrh-struktury-webu', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -384,152 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="navrh-struktury-webu.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/website-structure.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -728,7 +582,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -865,28 +719,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/obsahova-strategie.astro
+++ b/src/pages/sluzby/obsahova-strategie.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Obsahová strategie | Systematická tvorba obsahu',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/obsahova-strategie.html',
   ogTitle: 'Obsahová strategie',
   ogDescription: 'Strategický obsahový plán pro váš web a blog.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/obsahova-strategie.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/content-strategy.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/content-strategy.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('obsahova-strategie', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="obsahova-strategie.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/content-strategy.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -705,7 +559,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -842,28 +696,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/online-pr-a-linkbuilding.astro
+++ b/src/pages/sluzby/online-pr-a-linkbuilding.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Online PR a linkbuilding | Budování autority webu',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/online-pr-a-linkbuilding.html',
   ogTitle: 'Online PR a linkbuilding',
   ogDescription: 'Analýza odkazového profilu, strategický linkbuilding a umisťování PR článků.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/online-pr-a-linkbuilding.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/online-pr-linkbuilding.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/online-pr-linkbuilding.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('online-pr-a-linkbuilding', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,154 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="online-pr-a-linkbuilding.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/online-pr-linkbuilding.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -736,7 +588,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -873,28 +725,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/podpora-pro-startupy.astro
+++ b/src/pages/sluzby/podpora-pro-startupy.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Marketingová podpora pro startupy | Konzultace a mentoring',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/podpora-pro-startupy.html',
   ogTitle: 'Marketing pro startupy',
   ogDescription: 'Konzultace a mentoring pro mladé firmy.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/podpora-pro-startupy.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/support-for-startups.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/support-for-startups.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('podpora-pro-startupy', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="podpora-pro-startupy.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/support-for-startups.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -681,7 +535,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -818,28 +672,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/seo-audit.astro
+++ b/src/pages/sluzby/seo-audit.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'SEO Audit | Kompletní analýza webu a doporučení',
@@ -9,15 +11,12 @@ const seo: SeoInput = {
   ogTitle: 'SEO Audit – analýza webu',
   ogDescription: 'Získejte jasnou roadmapu pro růst organické návštěvnosti.',
   ogUrl: 'https://bangho.cz/sluzby/seo-audit.html',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/seo-audit.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/seo-audit.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/seo-audit.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('seo-audit', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -384,152 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="seo-audit.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/seo-audit.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -746,7 +600,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -883,28 +737,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/seo-redesign-webu.astro
+++ b/src/pages/sluzby/seo-redesign-webu.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'SEO a redesign webu | dostupnost, indexace, struktura',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/seo-redesign-webu.html',
   ogTitle: 'SEO dohled při redesignu',
   ogDescription: 'Redesign bez ztráty pozic a návštěvnosti.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/seo-redesign-webu.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/seo-redesign.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/seo-redesign.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('seo-redesign-webu', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="seo-redesign-webu.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/seo-redesign.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -739,7 +593,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -876,28 +730,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/seo-skoleni.astro
+++ b/src/pages/sluzby/seo-skoleni.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'SEO školení | Teorie a praxe na míru vašemu webu',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/seo-skoleni.html',
   ogTitle: 'SEO školení',
   ogDescription: 'Praktické školení SEO s ukázkami na vašem webu.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/seo-skoleni.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/seo-workshops.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/seo-workshops.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('seo-skoleni', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
         <!--DOPLNIT -->
 
@@ -384,152 +383,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="seo-skoleni.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/seo-workshops.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -739,7 +593,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -876,28 +730,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/skoleni-ai.astro
+++ b/src/pages/sluzby/skoleni-ai.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Školení AI | Efektivita a produktivita díky umělé inteligenci',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/skoleni-ai.html',
   ogTitle: 'Školení AI',
   ogDescription: 'Od praktických nástrojů pro běžné uživatele po lokální modely či vlastní RAG.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/skoleni-ai.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/ai-workshop.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/ai-workshop.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('skoleni-ai', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="skoleni-ai.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/ai-workshop.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -696,7 +550,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -833,28 +687,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/skoleni-marketingu.astro
+++ b/src/pages/sluzby/skoleni-marketingu.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Školení marketingu | Interaktivní kurz na míru',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/skoleni-marketingu.html',
   ogTitle: 'Školení marketingu',
   ogDescription: 'Strategie, kanály a měření výkonu.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/skoleni-marketingu.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/marketing-workshops.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/marketing-workshops.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('skoleni-marketingu', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="skoleni-marketingu.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/marketing-workshops.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -701,7 +555,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -838,28 +692,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>

--- a/src/pages/sluzby/technicky-audit-webu.astro
+++ b/src/pages/sluzby/technicky-audit-webu.astro
@@ -1,6 +1,8 @@
 ---
 import Base from '../../layouts/Base.astro';
+import NavCtas from '../../components/NavCtas.astro';
 import type { SeoInput } from '../../utils/seo';
+import { getServiceAlternates } from '../../data/serviceAlternates';
 
 const seo: SeoInput = {
   title: 'Technický SEO audit | Indexace, rychlost, Core Web Vitals',
@@ -8,15 +10,12 @@ const seo: SeoInput = {
   canonical: 'https://bangho.cz/sluzby/technicky-seo-audit.html',
   ogTitle: 'Technický SEO audit',
   ogDescription: 'Podrobná analýza technického stavu webu.',
-  alternates: [
-    { href: 'https://bangho.cz/sluzby/technicky-seo-audit.html', hreflang: 'cs' },
-    { href: 'https://bangho.cz/en/services/technical-seo-audit.html', hreflang: 'en' },
-    { href: 'https://bangho.cz/en/services/technical-seo-audit.html', hreflang: 'x-default' },
-  ],
+  alternates: getServiceAlternates('technicky-audit-webu', 'cs'),
 };
 ---
 
 <Base seo={seo} navClass="pt-25" navTopClass="pb-25">
+  <NavCtas lang="cs" />
   <Fragment slot="head">
 
         <!-- reCAPTCHA v3 -->
@@ -383,152 +382,7 @@ const seo: SeoInput = {
           }
         </script>
   </Fragment>
-<!-- header-area start -->
-<!-- slide-bar start -->
-        <aside class="slide-bar">
-          <div class="close-mobile-menu">
-            <a href="javascript:void(0);" aria-label="Zavřít menu"
-              ><i class="fas fa-times"></i
-            ></a>
-          </div>
-          <div class="mobile-header px-1 py-2 d-flex align-items-center">
-            <a
-              href="/"
-              class="d-flex align-items-center text-white text-decoration-none"
-            >
-              <img
-                src="../assets/img/logo.ico"
-                alt="Logo"
-                width="46"
-                height="46"
-                class="me-2"
-              />
-            </a>
-            <span class="mobile-email">martin@bangho.cz</span>
-          </div>
-          <nav class="side-mobile-menu" aria-label="Mobilní menu">
-            <ul id="mobile-menu-active">
-              <li class="has-dropdown">
-                <a href="#">SEO Služby</a>
-                <ul class="sub-menu">
-                  <li><a href="seo-audit.html">SEO Audit</a></li>
-                  <li>
-                    <a href="navrh-struktury-webu.html">Návrh struktury webu</a>
-                  </li>
-                  <li>
-                    <a href="seo-redesign-webu.html">SEO a redesign webu</a>
-                  </li>
-                  <li>
-                    <a href="analyza-klicovych-slov.html"
-                      >Analýza klíčových slov</a
-                    >
-                  </li>
-                  <li>
-                    <a href="technicky-audit-webu.html">Technická SEO analýza</a>
-                  </li>
-                  <li>
-                    <a href="online-pr-a-linkbuilding.html"
-                      >Online PR a linkbuilding</a
-                    >
-                  </li>
-                  <li>
-                    <a href="analyza-konkurence.html">Analýza konkurence</a>
-                  </li>
-                  <li><a href="kontinualni-seo.html">Kontinuální SEO</a></li>
-                  <li><a href="seo-skoleni.html">SEO školení</a></li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">Marketing</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="marketingova-strategie.html"
-                      >Marketingová strategie</a
-                    >
-                  </li>
-                  <li>
-                    <a href="obsahova-strategie.html">Obsahová strategie</a>
-                  </li>
-                  <li><a href="copywritting.html">Copywriting</a></li>
-                  <li>
-                    <a href="podpora-pro-startupy.html">Podpora pro sturupy</a>
-                  </li>
-                  <li>
-                    <a href="skoleni-marketingu.html">Školení marketingu</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="has-dropdown">
-                <a href="#">AI pro firmy</a>
-                <ul class="sub-menu">
-                  <li>
-                    <a href="geo-optimalizace-llms.html">Optimalizace pro LLMs</a>
-                  </li>
-                  <li><a href="konzultace-ai.html">Konzultace AI</a></li>
-                  <li>
-                    <a href="ai-agenti-a-automatizace.html"
-                      >AI agenti a automatitace</a
-                    >
-                  </li>
-                  <li><a href="skoleni-ai.html">Školení AI</a></li>
-                </ul>
-              </li>
-              <li><a href="https://bangho.cz/#works-section">Reference</a></li>
-              <li><a href="https://blog.bangho.cz/">Blog</a></li>
-              <li><a href="https://bangho.cz/#contact-section">Kontakt</a></li>
-            </ul>
-          </nav>
-          <div class="mobile-language-switcher mt-3 px-3 pb-3">
-            <div class="dropdown">
-              <button
-                class="btn dropdown-toggle text-white px-2 py-2"
-                type="button"
-                id="mobileLangDropdown"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <img
-                  src="../assets/img/flags/cz.svg"
-                  alt="Czech"
-                  width="20"
-                  height="20"
-                  class="me-2"
-                />
-                CZ
-              </button>
-              <ul class="dropdown-menu mt-2" aria-labelledby="mobileLangDropdown">
-                <li>
-                  <a class="dropdown-item py-2" href="technicky-audit-webu.html"
-                    ><img
-                      src="../assets/img/flags/cz.svg"
-                      alt="Czech"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />Čeština</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item py-2"
-                    href="../en/services/technical-seo-audit.html"
-                    ><img
-                      src="../assets/img/flags/gb.svg"
-                      alt="English"
-                      width="20"
-                      height="20"
-                      class="me-2"
-                    />English</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-        </aside>
-        <div class="body-overlay">
-<!-- slide-bar end -->
-
-        <main>
+<main>
           <!--our-services start-->
           <section class="service-details-wrapper pt-50 pb-30">
             <div class="container">
@@ -734,7 +588,7 @@ const seo: SeoInput = {
                         návrhem dalšího postupu.
                       </p>
                       <form
-                        action="../assets/mail.php"
+                        action="/assets/mail.php"
                         id="contact-form"
                         method="post"
                         role="form"
@@ -871,28 +725,28 @@ const seo: SeoInput = {
 
       <!-- JS here -->
 
-      <script src="../assets/js/vendor/modernizr-3.5.0.min.js"></script>
-      <script src="../assets/js/vendor/jquery-2.2.4.min.js"></script>
-      <script src="../assets/js/vendor/popper.min.js"></script>
-      <script src="../assets/js/vendor/bootstrap.min.js"></script>
-      <script src="../assets/js/slick.min.js"></script>
-      <script src="../assets/js/jquery.supermarquee.min.js"></script>
-      <script src="../assets/js/imagesloaded.pkgd.min.js"></script>
-      <script src="../assets/js/isotope.pkgd.min.js"></script>
-      <script src="../assets/js/jquery.magnific-popup.min.js"></script>
-      <script src="../assets/js/metisMenu.min.js"></script>
-      <script src="../assets/js/wow.min.js"></script>
-      <script src="../assets/js/aos.js"></script>
-      <script src="../assets/js/jquery.counterup.min.js"></script>
-      <script src="../assets/js/jquery.waypoints.min.js"></script>
-      <script src="../assets/js/tilt.jquery.min.js"></script>
-      <script src="../assets/js/jquery.easypiechart.min.js"></script>
-      <script src="../assets/js/jquery-ui.js"></script>
-      <script src="../assets/js/jquery.scrollUp.min.js"></script>
-      <script src="../assets/js/plugins.js"></script>
+      <script src="/assets/js/vendor/modernizr-3.5.0.min.js" is:inline></script>
+      <script src="/assets/js/vendor/jquery-2.2.4.min.js" is:inline></script>
+      <script src="/assets/js/vendor/popper.min.js" is:inline></script>
+      <script src="/assets/js/vendor/bootstrap.min.js" is:inline></script>
+      <script src="/assets/js/slick.min.js" is:inline></script>
+      <script src="/assets/js/jquery.supermarquee.min.js" is:inline></script>
+      <script src="/assets/js/imagesloaded.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/isotope.pkgd.min.js" is:inline></script>
+      <script src="/assets/js/jquery.magnific-popup.min.js" is:inline></script>
+      <script src="/assets/js/metisMenu.min.js" is:inline></script>
+      <script src="/assets/js/wow.min.js" is:inline></script>
+      <script src="/assets/js/aos.js" is:inline></script>
+      <script src="/assets/js/jquery.counterup.min.js" is:inline></script>
+      <script src="/assets/js/jquery.waypoints.min.js" is:inline></script>
+      <script src="/assets/js/tilt.jquery.min.js" is:inline></script>
+      <script src="/assets/js/jquery.easypiechart.min.js" is:inline></script>
+      <script src="/assets/js/jquery-ui.js" is:inline></script>
+      <script src="/assets/js/jquery.scrollUp.min.js" is:inline></script>
+      <script src="/assets/js/plugins.js" is:inline></script>
 
       <!--Custom JS here -->
-      <script src="js/main.js"></script>
+      <script src="/sluzby/js/main.js" is:inline></script>
 
   </Fragment>
 </Base>


### PR DESCRIPTION
## Summary
- remove duplicated service-page navigation markup in favor of MainNav slots via a reusable NavCtas component
- centralize service hreflang alternates in a helper shared by Czech and English pages
- normalize script asset references to root-relative URLs with inline delivery to keep the Astro build happy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2bbaf678832e8c7a8a8182ec306f