### PR TITLE
Refactor image handling to use public assets metadata

### DIFF
--- a/src/components/ResponsiveImage.astro
+++ b/src/components/ResponsiveImage.astro
@@ -1,0 +1,63 @@
+---
+export interface ResponsiveSource {
+  srcset: string;
+  type?: string;
+  media?: string;
+  sizes?: string;
+}
+
+export interface ResponsiveImageProps {
+  alt: string;
+  src: string;
+  width: number;
+  height: number;
+  sources?: ResponsiveSource[];
+  srcset?: string;
+  sizes?: string;
+  loading?: 'lazy' | 'eager';
+  decoding?: 'async' | 'auto' | 'sync';
+  pictureClass?: string;
+  class?: string;
+  style?: string;
+  [key: string]: unknown;
+}
+
+const {
+  alt,
+  src,
+  width,
+  height,
+  sources = [],
+  srcset,
+  sizes,
+  loading = 'lazy',
+  decoding = 'async',
+  pictureClass,
+  class: imgClass,
+  style,
+  ...rest
+} = Astro.props as ResponsiveImageProps;
+---
+<picture class={pictureClass}>
+  {sources.map((source) => (
+    <source
+      type={source.type}
+      srcset={source.srcset}
+      media={source.media}
+      sizes={source.sizes ?? sizes}
+    />
+  ))}
+  <img
+    src={src}
+    alt={alt}
+    width={width}
+    height={height}
+    loading={loading}
+    decoding={decoding}
+    srcset={srcset}
+    sizes={sizes}
+    class={imgClass}
+    style={style}
+    {...rest}
+  />
+</picture>

--- a/src/data/media.ts
+++ b/src/data/media.ts
@@ -1,0 +1,124 @@
+import type { ResponsiveImageProps, ResponsiveSource } from '../components/ResponsiveImage.astro';
+
+export type ImageSource = ResponsiveSource;
+
+export type ImageMetadata = Pick<
+  ResponsiveImageProps,
+  'src' | 'width' | 'height' | 'srcset' | 'sizes' | 'sources'
+>;
+
+type ImageMap = Record<string, ImageMetadata>;
+
+type GalleryMap = Record<string, ImageMetadata[]>;
+
+export const heroPortrait: ImageMetadata = {
+  src: '/assets/img/hero/me.png',
+  width: 1920,
+  height: 1920,
+  sources: [
+    {
+      type: 'image/webp',
+      srcset: '/assets/img/hero/me.webp',
+    },
+  ],
+};
+
+export const testimonialPortraits: ImageMap = {
+  kejval: {
+    src: '/assets/img/testimonials/user/kejval.jpg',
+    width: 491,
+    height: 491,
+  },
+  zatkovic: {
+    src: '/assets/img/testimonials/user/zatkovic.webp',
+    width: 1365,
+    height: 1365,
+  },
+  vlcek: {
+    src: '/assets/img/testimonials/user/vlcek.jpg',
+    width: 1310,
+    height: 1310,
+  },
+  kapic: {
+    src: '/assets/img/testimonials/user/kapic.jpg',
+    width: 1638,
+    height: 1638,
+  },
+  architekti: {
+    src: '/assets/img/testimonials/user/architekti.jpg',
+    width: 300,
+    height: 300,
+  },
+};
+
+export const portfolioGalleryImages: GalleryMap = {
+  o2: [
+    {
+      src: '/assets/img/portfolio-gallery/o2_2.png',
+      width: 1119,
+      height: 560,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/o2_3.png',
+      width: 1114,
+      height: 557,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/o2_4.png',
+      width: 1114,
+      height: 557,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/o2_5.png',
+      width: 600,
+      height: 300,
+    },
+  ],
+  sofa: [
+    {
+      src: '/assets/img/portfolio-gallery/sofa_2.png',
+      width: 1617,
+      height: 808,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/sofa_3.png',
+      width: 1699,
+      height: 850,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/sofa_4.png',
+      width: 1701,
+      height: 850,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/sofa_5.png',
+      width: 1703,
+      height: 852,
+    },
+  ],
+  security: [
+    {
+      src: '/assets/img/portfolio-gallery/avast.png',
+      width: 1631,
+      height: 842,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/norton.png',
+      width: 1612,
+      height: 833,
+    },
+    {
+      src: '/assets/img/portfolio-gallery/lifelock.png',
+      width: 1612,
+      height: 861,
+    },
+  ],
+};
+
+export const iconImages: ImageMap = {
+  n8n: {
+    src: '/assets/img/icons/n8n.png',
+    width: 500,
+    height: 500,
+  },
+};

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,5 +1,12 @@
 ---
 import Base from '../../layouts/Base.astro';
+import ResponsiveImage from '../../components/ResponsiveImage.astro';
+import {
+  heroPortrait,
+  portfolioGalleryImages,
+  testimonialPortraits,
+  iconImages,
+} from '../../data/media';
 import type { SeoInput } from '../../utils/seo';
 import '../../styles/landing/hero.css';
 import '../../styles/landing/services.css';
@@ -347,7 +354,11 @@ const seo: SeoInput = {
                     class="hero-image-box d-md-none wow fadeInRight"
                     data-wow-delay="0.3s"
                   >
-                    <img src="/assets/img/hero/me.webp" alt="" />
+                    <ResponsiveImage
+                      {...heroPortrait}
+                      alt="Martin Bangho"
+                      loading="eager"
+                    />
                   </div>
                   <p class="lead wow fadeInLeft" data-wow-delay="0.3s">
                     I design data-driven SEO strategies that deliver results even
@@ -391,15 +402,11 @@ const seo: SeoInput = {
                   data-wow-delay="0.2"
                   style="position: relative; width: 100%"
                 >
-                  <img
-                    src="/assets/img/hero/me.webp"
-                    alt=""
-                    style="
-                      width: 100%;
-                      max-width: 520px;
-                      height: auto;
-                      display: block;
-                    "
+                  <ResponsiveImage
+                    {...heroPortrait}
+                    alt="Martin Bangho"
+                    loading="eager"
+                    style="width: 100%; max-width: 520px; height: auto; display: block;"
                   />
                 </div>
               </div>
@@ -712,18 +719,14 @@ const seo: SeoInput = {
                   </div>
 
                   <div class="portfolio_gallery" data-carousel="portfolio">
+                    {portfolioGalleryImages.o2.map((image, index) => (
                       <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/o2_2.png" alt="" />
+                        <ResponsiveImage
+                          {...image}
+                          alt={`O2 project sample ${index + 1}`}
+                        />
                       </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/o2_3.png" alt="" />
-                      </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/o2_4.png" alt="" />
-                      </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/o2_5.png" alt="" />
-                      </div>
+                    ))}
                   </div>
 
                   <div class="portfolio_description">
@@ -813,18 +816,14 @@ const seo: SeoInput = {
                   </div>
 
                   <div class="portfolio_gallery" data-carousel="portfolio">
+                    {portfolioGalleryImages.sofa.map((image, index) => (
                       <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/sofa_2.png" alt="" />
+                        <ResponsiveImage
+                          {...image}
+                          alt={`SOFA project sample ${index + 1}`}
+                        />
                       </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/sofa_3.png" alt="" />
-                      </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/sofa_4.png" alt="" />
-                      </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/sofa_5.png" alt="" />
-                      </div>
+                    ))}
                   </div>
 
                   <div class="portfolio_description">
@@ -929,15 +928,14 @@ const seo: SeoInput = {
                   </div>
 
                   <div class="portfolio_gallery" data-carousel="portfolio">
+                    {portfolioGalleryImages.security.map((image, index) => (
                       <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/avast.png" alt="" />
+                        <ResponsiveImage
+                          {...image}
+                          alt={`Gen Digital project sample ${index + 1}`}
+                        />
                       </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/norton.png" alt="" />
-                      </div>
-                      <div class="gallery_item">
-                          <img src="/assets/img/portfolio-gallery/lifelock.png" alt="" />
-                      </div>
+                    ))}
                   </div>
 
                   <div class="portfolio_description">
@@ -1145,7 +1143,10 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/n8n.png" alt="" />
+                        <ResponsiveImage
+                          {...iconImages.n8n}
+                          alt="n8n"
+                        />
                       </div>
                       <div class="number">AI Agents & <br />Automation</div>
                     </div>
@@ -1204,9 +1205,9 @@ const seo: SeoInput = {
                           <h6>Jakub Kejval</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/kejval.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.kejval}
+                            alt="Jakub Kejval"
                           />
                         </div>
                       </div>
@@ -1297,9 +1298,9 @@ const seo: SeoInput = {
                           <h6>Martin<br />Žatkovič</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/zatkovic.webp"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.zatkovic}
+                            alt="Jakub Žatkovič"
                           />
                         </div>
                       </div>
@@ -1387,9 +1388,9 @@ const seo: SeoInput = {
                           <h6>Lukáš<br />Vlček</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/vlcek.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.vlcek}
+                            alt="David Vlček"
                           />
                         </div>
                       </div>
@@ -1478,9 +1479,9 @@ const seo: SeoInput = {
                           <h6>UHUMDRUM</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/kapic.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.kapic}
+                            alt="Jakub Kapic"
                           />
                         </div>
                       </div>
@@ -1571,9 +1572,9 @@ const seo: SeoInput = {
                           <h6>Digitální Architekti</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/architekti.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.architekti}
+                            alt="Digital Architects"
                           />
                         </div>
                       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
+import ResponsiveImage from '../components/ResponsiveImage.astro';
+import {
+  heroPortrait,
+  portfolioGalleryImages,
+  testimonialPortraits,
+  iconImages,
+} from '../data/media';
 import type { SeoInput } from '../utils/seo';
 import '../styles/landing/hero.css';
 import '../styles/landing/services.css';
@@ -381,7 +388,11 @@ const seo: SeoInput = {
                     class="hero-image-box d-md-none wow fadeInRight"
                     data-wow-delay="0.3s"
                   >
-                    <img src="/assets/img/hero/me.webp" alt="" />
+                    <ResponsiveImage
+                      {...heroPortrait}
+                      alt="Martin Bangho"
+                      loading="eager"
+                    />
                   </div>
                   <p class="lead wow fadeInLeft" data-wow-delay="0.3s">
                     Navrhuji datově podložené SEO strategie, které přinášejí
@@ -425,15 +436,11 @@ const seo: SeoInput = {
                   data-wow-delay="0.2"
                   style="position: relative; width: 100%"
                 >
-                  <img
-                    src="/assets/img/hero/me.webp"
-                    alt=""
-                    style="
-                      width: 100%;
-                      max-width: 520px;
-                      height: auto;
-                      display: block;
-                    "
+                  <ResponsiveImage
+                    {...heroPortrait}
+                    alt="Martin Bangho"
+                    loading="eager"
+                    style="width: 100%; max-width: 520px; height: auto; display: block;"
                   />
                 </div>
               </div>
@@ -824,18 +831,14 @@ const seo: SeoInput = {
             </div>
 
             <div class="portfolio_gallery" data-carousel="portfolio">
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/o2_2.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/o2_3.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/o2_4.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/o2_5.png" alt="" />
-              </div>
+              {portfolioGalleryImages.o2.map((image, index) => (
+                <div class="gallery_item">
+                  <ResponsiveImage
+                    {...image}
+                    alt={`Ukázka projektu O2 ${index + 1}`}
+                  />
+                </div>
+              ))}
             </div>
 
             <div class="portfolio_description">
@@ -946,18 +949,14 @@ const seo: SeoInput = {
             </div>
 
             <div class="portfolio_gallery" data-carousel="portfolio">
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/sofa_2.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/sofa_3.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/sofa_4.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/sofa_5.png" alt="" />
-              </div>
+              {portfolioGalleryImages.sofa.map((image, index) => (
+                <div class="gallery_item">
+                  <ResponsiveImage
+                    {...image}
+                    alt={`Ukázka projektu SOFA ${index + 1}`}
+                  />
+                </div>
+              ))}
             </div>
 
             <div class="portfolio_description">
@@ -1085,15 +1084,14 @@ const seo: SeoInput = {
             </div>
 
             <div class="portfolio_gallery" data-carousel="portfolio">
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/avast.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/norton.png" alt="" />
-              </div>
-              <div class="gallery_item">
-                <img src="./assets/img/portfolio-gallery/lifelock.png" alt="" />
-              </div>
+              {portfolioGalleryImages.security.map((image, index) => (
+                <div class="gallery_item">
+                  <ResponsiveImage
+                    {...image}
+                    alt={`Ukázka projektu Gen Digital ${index + 1}`}
+                  />
+                </div>
+              ))}
             </div>
 
             <div class="portfolio_description">
@@ -1355,7 +1353,10 @@ const seo: SeoInput = {
                   <div class="skill-item wow fadeInUp" data-wow-delay="0.2s">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/n8n.png" alt="" />
+                        <ResponsiveImage
+                          {...iconImages.n8n}
+                          alt="n8n"
+                        />
                       </div>
                       <div class="number">AI Agenti & <br />Automatizace</div>
                     </div>
@@ -1414,9 +1415,9 @@ const seo: SeoInput = {
                           <h6>Jakub Kejval</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/kejval.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.kejval}
+                            alt="Jakub Kejval"
                           />
                         </div>
                       </div>
@@ -1507,9 +1508,9 @@ const seo: SeoInput = {
                           <h6>Martin<br />Žatkovič</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/zatkovic.webp"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.zatkovic}
+                            alt="Jakub Žatkovič"
                           />
                         </div>
                       </div>
@@ -1597,9 +1598,9 @@ const seo: SeoInput = {
                           <h6>Lukáš<br />Vlček</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/vlcek.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.vlcek}
+                            alt="David Vlček"
                           />
                         </div>
                       </div>
@@ -1687,9 +1688,9 @@ const seo: SeoInput = {
                           <h6>UHUMDRUM</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/kapic.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.kapic}
+                            alt="Jakub Kapic"
                           />
                         </div>
                       </div>
@@ -1780,9 +1781,9 @@ const seo: SeoInput = {
                           <h6>Digitální Architekti</h6>
                         </div>
                         <div class="image-box">
-                          <img
-                            src="/assets/img/testimonials/user/architekti.jpg"
-                            alt=""
+                          <ResponsiveImage
+                            {...testimonialPortraits.architekti}
+                            alt="Digitální architekti"
                           />
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- add a reusable ResponsiveImage component that renders picture/img elements with lazy-loading defaults
- replace inline image metadata with structured data pointing at files in public/assets
- update the Czech and English landing pages to consume the new metadata for hero, gallery, testimonial, and automation images

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02a08d39c832ea8c7047239240bf2