### PR TITLE
Add offline fallback page and base-aware precache support

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -5,11 +5,43 @@ const PRECACHE_NAME = `precache-${CACHE_VERSION}`;
 const PAGE_CACHE = `pages-${CACHE_VERSION}`;
 const FONT_CACHE = `font-${CACHE_VERSION}`;
 const IMAGE_CACHE = `image-${CACHE_VERSION}`;
-const OFFLINE_URL = '/offline/index.html';
+const BASE_URL = typeof __ASTRO_BASE__ !== 'undefined' ? __ASTRO_BASE__ : '/';
+const NORMALIZED_BASE = normalizeBase(BASE_URL);
+const OFFLINE_URL = withBase('/offline/index.html');
 
 const PRECACHE_MANIFEST =
   typeof __PRECACHE_MANIFEST__ !== 'undefined' ? __PRECACHE_MANIFEST__ : [];
 const PRECACHE_URLS = Array.from(new Set(PRECACHE_MANIFEST.map((entry) => entry.url)));
+
+if (!PRECACHE_URLS.includes(OFFLINE_URL)) {
+  PRECACHE_URLS.push(OFFLINE_URL);
+}
+
+function normalizeBase(base) {
+  if (!base || base === '/' || base === './') {
+    return '';
+  }
+
+  let normalized = base;
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+
+  if (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
+function withBase(pathname) {
+  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  if (!NORMALIZED_BASE) {
+    return normalizedPath;
+  }
+
+  return `${NORMALIZED_BASE}${normalizedPath}`;
+}
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();

--- a/src/pages/offline.astro
+++ b/src/pages/offline.astro
@@ -1,23 +1,104 @@
 ---
 import Base from '../layouts/Base.astro';
+import type { SeoInput } from '../utils/seo';
 
-const seo = {
-  title: 'Offline režim',
-  description: 'Tato stránka je dostupná i bez připojení k internetu.',
+const homeHref = import.meta.env.BASE_URL || '/';
+
+const seo: SeoInput = {
+  title: 'Jste offline | Martin Bangho',
+  description:
+    'Vypadá to, že jste offline. Zkuste zkontrolovat připojení k internetu nebo stránku načíst znovu.',
+  canonical: 'https://bangho.cz/offline/',
+  ogDescription:
+    'Zkuste zkontrolovat připojení k internetu nebo stránku načíst znovu, aby se vám web Martina Bangha načetl správně.',
+  ogUrl: 'https://bangho.cz/offline/',
 };
 ---
 
-<Base seo={seo}>
-  <section class="offline-state pt-120 pb-120">
-    <div class="container text-center">
-      <h1>Jste offline</h1>
+<Base seo={seo} navClass="is-transparent">
+  <Fragment slot="head">
+    <style>
+      .offline-page {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 60vh;
+        padding: 3rem 1.5rem;
+        text-align: center;
+      }
+
+      .offline-card {
+        max-width: 32rem;
+        margin: 0 auto;
+        padding: 2.5rem 2rem;
+        border-radius: 1.5rem;
+        background: rgba(255, 255, 255, 0.85);
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.15);
+        backdrop-filter: blur(12px);
+      }
+
+      .offline-card h1 {
+        font-size: clamp(2rem, 5vw, 2.75rem);
+        margin-bottom: 1rem;
+      }
+
+      .offline-card p {
+        margin-bottom: 1.75rem;
+        font-size: 1.05rem;
+        line-height: 1.6;
+      }
+
+      .offline-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+      }
+
+      .offline-actions a,
+      .offline-actions button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.85rem 1.5rem;
+        border-radius: 9999px;
+        font-weight: 600;
+        border: none;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .offline-actions a {
+        background: #1f2937;
+        color: #fff;
+        text-decoration: none;
+      }
+
+      .offline-actions button {
+        background: #f3f4f6;
+        color: #1f2937;
+      }
+
+      .offline-actions a:hover,
+      .offline-actions button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+      }
+    </style>
+  </Fragment>
+
+  <main class="offline-page">
+    <section class="offline-card" aria-labelledby="offline-heading">
+      <h1 id="offline-heading">Vypadá to, že jste offline</h1>
       <p>
-        Obsah se načte hned, jakmile budete mít znovu připojení k internetu. Zatím můžete
-        procházet uložené stránky nebo se vrátit na úvodní stranu.
+        Nemůžeme se připojit k internetu, ale obsah máte k dispozici i bez něj.
+        Jakmile budete online, obnovte stránku a pokračujte ve čtení.
       </p>
-      <p>
-        <a class="btn btn-primary" href="/">Zpět na úvod</a>
-      </p>
-    </div>
-  </section>
+      <div class="offline-actions">
+        <a href={homeHref}>Zpět na úvodní stránku</a>
+        <button type="button" onclick="window.location.reload()">Zkusit znovu</button>
+      </div>
+    </section>
+  </main>
 </Base>


### PR DESCRIPTION
## Summary
- add an offline fallback page with messaging and base-aware navigation
- update the service worker to derive the offline URL with withBase and ensure it is precached
- enhance the custom PWA integration to inject the Astro base path into the precache manifest and service worker

## Testing
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68d1655fa44c832ebcd8be0dc17c4033