### PR TITLE
Ensure assets respect base path

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,8 @@
 ---
 import type { Locale } from '../data/navigation';
 import { socialLinks } from '../data/socials';
-import { resolveAssetPath, withBase } from '../utils/paths';
+import { prependForwardSlash, withBase } from '../utils/paths';
+import { resolvePublicAsset } from '../utils/publicAssets';
 import '../styles/components/footer.css';
 
 interface Props {
@@ -20,7 +21,7 @@ const content = {
       'Potion je newsletter, který každých 14 dní přináší to nejdůležitější ze světa SEO, AI a marketingu – stručně, prakticky a bez balastu.',
     ctaHref: 'https://www.potion.cz',
     ctaLabel: 'Potion Newsletter',
-    privacyHref: '/zpracovani-osobnich-udaju',
+    privacyHref: 'zpracovani-osobnich-udaju',
     privacyLabel: 'Zpracování osobních údajů',
     copyright:
       '© 2025 Martin Bangho<br />SEO Konzultant & AI Strategist',
@@ -34,7 +35,7 @@ const content = {
       'Potion is a newsletter that brings you the most important news from the world of SEO, AI, and marketing every 14 days – concisely, practically, and without fluff.',
     ctaHref: 'https://www.potion.cz',
     ctaLabel: 'Potion Newsletter',
-    privacyHref: '/en/processing-of-personal-data',
+    privacyHref: 'en/processing-of-personal-data',
     privacyLabel: 'Privacy Policy',
     copyright:
       '© 2025 Martin Bangho<br />SEO Consultant & AI Strategist',
@@ -52,7 +53,7 @@ const content = {
 }>;
 
 const localeContent = content[lang];
-const privacyHref = withBase(localeContent.privacyHref);
+const privacyHref = withBase(prependForwardSlash(localeContent.privacyHref));
 const [
   footerShape1,
   footerShape2,
@@ -67,7 +68,7 @@ const [
   'sluzby/img/shape/star-5b.svg',
   'sluzby/img/shape/star-5b.svg',
   'sluzby/img/shape/line-round-7b.svg',
-].map(resolveAssetPath);
+].map(resolvePublicAsset);
 ---
 <footer class="footer-area theme-footer-three pt-145 pt-lg-100 pt-sm-100">
   <img class="footer-shape shape-1b" src={footerShape1} alt="shape" />

--- a/src/components/MainNav.astro
+++ b/src/components/MainNav.astro
@@ -4,9 +4,9 @@ import { getNavigation } from '../data/navigation';
 import {
   isExternalHref,
   prependForwardSlash,
-  resolveAssetPath,
   withBase,
 } from '../utils/paths';
+import { resolvePublicAsset } from '../utils/publicAssets';
 import '../styles/components/navigation.css';
 
 interface Props {
@@ -38,7 +38,9 @@ const resolveNavigationHref = (
 };
 
 const logoHref = resolveNavigationHref(navigation.logoHref) ?? withBase('');
-const logoSrc = resolveAssetPath('assets/img/logo.ico');
+const logoSrc = resolvePublicAsset(
+  new URL('../../public/assets/img/logo.ico', import.meta.url),
+);
 const menu = navigation.menu.map((item) => ({
   ...item,
   href: resolveNavigationHref(item.href, item.external),
@@ -50,7 +52,7 @@ const menu = navigation.menu.map((item) => ({
 const languages = navigation.languages.map((language) => ({
   ...language,
   href: resolveNavigationHref(language.href),
-  flag: resolveAssetPath(language.flag),
+  flag: resolvePublicAsset(language.flag),
 }));
 const headerClasses = ['theme-main-menu', 'theme-menu-three', headerClass]
   .filter(Boolean)

--- a/src/components/ResponsiveImage.astro
+++ b/src/components/ResponsiveImage.astro
@@ -1,6 +1,10 @@
 ---
+import { resolvePublicAsset } from '../utils/publicAssets';
+
+type MaybeUrl = string | URL;
+
 export interface ResponsiveSource {
-  srcset: string;
+  srcset: MaybeUrl;
   type?: string;
   media?: string;
   sizes?: string;
@@ -8,11 +12,11 @@ export interface ResponsiveSource {
 
 export interface ResponsiveImageProps {
   alt: string;
-  src: string;
+  src: MaybeUrl;
   width: number;
   height: number;
   sources?: ResponsiveSource[];
-  srcset?: string;
+  srcset?: MaybeUrl;
   sizes?: string;
   loading?: 'lazy' | 'eager';
   decoding?: 'async' | 'auto' | 'sync';
@@ -39,24 +43,28 @@ const {
 } = Astro.props as ResponsiveImageProps;
 
 const decoding = decodingProp ?? (loading === 'eager' ? 'sync' : 'async');
+const resolveAsset = (value: MaybeUrl | undefined) =>
+  value instanceof URL ? resolvePublicAsset(value) : value;
+const resolvedSrc = resolveAsset(src);
+const resolvedSrcset = resolveAsset(srcset);
 ---
 <picture class={pictureClass}>
-  {sources.map((source) => (
-    <source
-      type={source.type}
-      srcset={source.srcset}
-      media={source.media}
-      sizes={source.sizes ?? sizes}
-    />
-  ))}
+{sources.map((source) => (
+  <source
+    type={source.type}
+    srcset={resolveAsset(source.srcset)!}
+    media={source.media}
+    sizes={source.sizes ?? sizes}
+  />
+))}
   <img
-    src={src}
+    src={resolvedSrc!}
     alt={alt}
     width={width}
     height={height}
     loading={loading}
     decoding={decoding}
-    srcset={srcset}
+    srcset={resolvedSrcset}
     sizes={sizes}
     class={imgClass}
     style={style}

--- a/src/data/media.ts
+++ b/src/data/media.ts
@@ -1,7 +1,7 @@
 import type { ResponsiveImageProps, ResponsiveSource } from '../components/ResponsiveImage.astro';
-import { resolveAssetPath } from '../utils/paths';
 
-const assetPath = (path: string) => resolveAssetPath(`assets/${path}`);
+const assetUrl = (path: string) =>
+  new URL(`../../public/assets/${path}`, import.meta.url);
 
 export type ImageSource = ResponsiveSource;
 
@@ -15,40 +15,40 @@ type ImageMap = Record<string, ImageMetadata>;
 type GalleryMap = Record<string, ImageMetadata[]>;
 
 export const heroPortrait: ImageMetadata = {
-  src: assetPath('img/hero/me.png'),
+  src: assetUrl('img/hero/me.png'),
   width: 1920,
   height: 1920,
   sources: [
     {
       type: 'image/webp',
-      srcset: assetPath('img/hero/me.webp'),
+      srcset: assetUrl('img/hero/me.webp'),
     },
   ],
 };
 
 export const testimonialPortraits: ImageMap = {
   kejval: {
-    src: assetPath('img/testimonials/user/kejval.jpg'),
+    src: assetUrl('img/testimonials/user/kejval.jpg'),
     width: 491,
     height: 491,
   },
   zatkovic: {
-    src: assetPath('img/testimonials/user/zatkovic.webp'),
+    src: assetUrl('img/testimonials/user/zatkovic.webp'),
     width: 1365,
     height: 1365,
   },
   vlcek: {
-    src: assetPath('img/testimonials/user/vlcek.jpg'),
+    src: assetUrl('img/testimonials/user/vlcek.jpg'),
     width: 1310,
     height: 1310,
   },
   kapic: {
-    src: assetPath('img/testimonials/user/kapic.jpg'),
+    src: assetUrl('img/testimonials/user/kapic.jpg'),
     width: 1638,
     height: 1638,
   },
   architekti: {
-    src: assetPath('img/testimonials/user/architekti.jpg'),
+    src: assetUrl('img/testimonials/user/architekti.jpg'),
     width: 300,
     height: 300,
   },
@@ -57,61 +57,61 @@ export const testimonialPortraits: ImageMap = {
 export const portfolioGalleryImages: GalleryMap = {
   o2: [
     {
-      src: assetPath('img/portfolio-gallery/o2_2.png'),
+      src: assetUrl('img/portfolio-gallery/o2_2.png'),
       width: 1119,
       height: 560,
     },
     {
-      src: assetPath('img/portfolio-gallery/o2_3.png'),
+      src: assetUrl('img/portfolio-gallery/o2_3.png'),
       width: 1114,
       height: 557,
     },
     {
-      src: assetPath('img/portfolio-gallery/o2_4.png'),
+      src: assetUrl('img/portfolio-gallery/o2_4.png'),
       width: 1114,
       height: 557,
     },
     {
-      src: assetPath('img/portfolio-gallery/o2_5.png'),
+      src: assetUrl('img/portfolio-gallery/o2_5.png'),
       width: 600,
       height: 300,
     },
   ],
   sofa: [
     {
-      src: assetPath('img/portfolio-gallery/sofa_2.png'),
+      src: assetUrl('img/portfolio-gallery/sofa_2.png'),
       width: 1617,
       height: 808,
     },
     {
-      src: assetPath('img/portfolio-gallery/sofa_3.png'),
+      src: assetUrl('img/portfolio-gallery/sofa_3.png'),
       width: 1699,
       height: 850,
     },
     {
-      src: assetPath('img/portfolio-gallery/sofa_4.png'),
+      src: assetUrl('img/portfolio-gallery/sofa_4.png'),
       width: 1701,
       height: 850,
     },
     {
-      src: assetPath('img/portfolio-gallery/sofa_5.png'),
+      src: assetUrl('img/portfolio-gallery/sofa_5.png'),
       width: 1703,
       height: 852,
     },
   ],
   security: [
     {
-      src: assetPath('img/portfolio-gallery/avast.png'),
+      src: assetUrl('img/portfolio-gallery/avast.png'),
       width: 1631,
       height: 842,
     },
     {
-      src: assetPath('img/portfolio-gallery/norton.png'),
+      src: assetUrl('img/portfolio-gallery/norton.png'),
       width: 1612,
       height: 833,
     },
     {
-      src: assetPath('img/portfolio-gallery/lifelock.png'),
+      src: assetUrl('img/portfolio-gallery/lifelock.png'),
       width: 1612,
       height: 861,
     },
@@ -120,7 +120,7 @@ export const portfolioGalleryImages: GalleryMap = {
 
 export const iconImages: ImageMap = {
   n8n: {
-    src: assetPath('img/icons/n8n.png'),
+    src: assetUrl('img/icons/n8n.png'),
     width: 500,
     height: 500,
   },

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -21,7 +21,7 @@ export interface LanguageLink {
   label: string;
   shortLabel: string;
   href: string;
-  flag: string;
+  flag: URL;
   hreflang: string;
 }
 
@@ -33,6 +33,11 @@ export interface NavigationData {
   languages: LanguageLink[];
   languageButtonLabel: string;
 }
+
+const flagIcons = {
+  cs: new URL('../../public/assets/img/flags/cz.svg', import.meta.url),
+  en: new URL('../../public/assets/img/flags/gb.svg', import.meta.url),
+} as const;
 
 const navigation: Record<Locale, NavigationData> = {
   cs: {
@@ -104,7 +109,7 @@ const navigation: Record<Locale, NavigationData> = {
         label: 'Čeština',
         shortLabel: 'CZ',
         href: '',
-        flag: 'assets/img/flags/cz.svg',
+        flag: flagIcons.cs,
         hreflang: 'cs',
       },
       {
@@ -112,7 +117,7 @@ const navigation: Record<Locale, NavigationData> = {
         label: 'English',
         shortLabel: 'EN',
         href: 'en/',
-        flag: 'assets/img/flags/gb.svg',
+        flag: flagIcons.en,
         hreflang: 'en',
       },
     ],
@@ -187,7 +192,7 @@ const navigation: Record<Locale, NavigationData> = {
         label: 'Čeština',
         shortLabel: 'CZ',
         href: '',
-        flag: 'assets/img/flags/cz.svg',
+        flag: flagIcons.cs,
         hreflang: 'cs',
       },
       {
@@ -195,7 +200,7 @@ const navigation: Record<Locale, NavigationData> = {
         label: 'English',
         shortLabel: 'EN',
         href: 'en/',
-        flag: 'assets/img/flags/gb.svg',
+        flag: flagIcons.en,
         hreflang: 'en',
       },
     ],

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,7 +4,7 @@ import Footer from '../components/Footer.astro';
 import type { Locale } from '../data/navigation';
 import type { SeoInput } from '../utils/seo';
 import { buildSeoTags } from '../utils/seo';
-import { resolveAssetPath, withBase } from '../utils/paths';
+import { resolvePublicAsset } from '../utils/publicAssets';
 import '../styles/tokens.css';
 import '../styles/base.css';
 
@@ -24,19 +24,75 @@ const {
 
 const seoTags = seo ? buildSeoTags(lang, seo) : null;
 const shouldRegisterSw = import.meta.env.PROD;
-const serviceWorkerPath = withBase('sw.js');
+const serviceWorkerPath = resolvePublicAsset('sw.js');
+const appleTouchIcon = resolvePublicAsset(
+  new URL('../../public/apple-touch-icon.png', import.meta.url),
+);
+const favicon32 = resolvePublicAsset(
+  new URL('../../public/favicon-32x32.png', import.meta.url),
+);
+const favicon16 = resolvePublicAsset(
+  new URL('../../public/favicon-16x16.png', import.meta.url),
+);
+const siteManifest = resolvePublicAsset(
+  new URL('../../public/site.webmanifest', import.meta.url),
+);
+const safariPinnedTab = resolvePublicAsset(
+  new URL('../../public/safari-pinned-tab.svg', import.meta.url),
+);
 const backgrounds = {
-  selectArrow: resolveAssetPath('assets/img/icons/down-arrow.svg'),
-  heroBanner: resolveAssetPath('assets/img/hero/hero-bg-shap-3a.svg'),
-  featureShape: resolveAssetPath('sluzby/img/shape/topograph-1c.svg'),
-  authorQuote: resolveAssetPath('assets/img/icon/icon-45.svg'),
-  projectInfo: resolveAssetPath('assets/img/work/big-img-01.jpg'),
-  videoPrimary: resolveAssetPath('assets/img/video/video-1b.jpg'),
-  videoSecondary: resolveAssetPath('assets/img/video/video-2d.jpg'),
-  priceBackground: resolveAssetPath('img/bg/price-bg-1c.svg'),
-  planShape: resolveAssetPath('sluzby/img/shape/topograph-2c.svg'),
-  errorSpiral: resolveAssetPath('sluzby/img/shape/spiral-1e.svg'),
+  selectArrow: resolvePublicAsset('assets/img/icons/down-arrow.svg'),
+  heroBanner: resolvePublicAsset('assets/img/hero/hero-bg-shap-3a.svg'),
+  featureShape: resolvePublicAsset('sluzby/img/shape/topograph-1c.svg'),
+  authorQuote: resolvePublicAsset('assets/img/icon/icon-45.svg'),
+  projectInfo: resolvePublicAsset('assets/img/work/big-img-01.jpg'),
+  videoPrimary: resolvePublicAsset('assets/img/video/video-1b.jpg'),
+  videoSecondary: resolvePublicAsset('assets/img/video/video-2d.jpg'),
+  priceBackground: resolvePublicAsset('img/bg/price-bg-1c.svg'),
+  planShape: resolvePublicAsset('sluzby/img/shape/topograph-2c.svg'),
+  errorSpiral: resolvePublicAsset('sluzby/img/shape/spiral-1e.svg'),
 };
+const backgroundStyles = `
+  .tj-nice-select::after {
+    background-image: url("${backgrounds.selectArrow}");
+  }
+
+  .theme-banner-three::before {
+    background-image: url("${backgrounds.heroBanner}");
+  }
+
+  .feature-style-five::before {
+    background-image: url("${backgrounds.featureShape}");
+  }
+
+  .author-blockquote::before {
+    background-image: url("${backgrounds.authorQuote}");
+  }
+
+  .project-info {
+    background-image: url("${backgrounds.projectInfo}");
+  }
+
+  .video-wrapper {
+    background-image: url("${backgrounds.videoPrimary}");
+  }
+
+  .techy-video {
+    background-image: url("${backgrounds.videoSecondary}");
+  }
+
+  .bg-wrapper-one {
+    background-image: url("${backgrounds.priceBackground}");
+  }
+
+  .plan::before {
+    background-image: url("${backgrounds.planShape}");
+  }
+
+  .error-page-bg {
+    background-image: url("${backgrounds.errorSpiral}");
+  }
+`;
 ---
 
 <!DOCTYPE html>
@@ -47,25 +103,11 @@ const backgrounds = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="msapplication-TileColor" content="#9f00a7" />
     <meta name="theme-color" content="#ffffff" />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href={withBase('apple-touch-icon.png')}
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href={withBase('favicon-32x32.png')}
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href={withBase('favicon-16x16.png')}
-    />
-    <link rel="manifest" href={withBase('site.webmanifest')} />
-    <link rel="mask-icon" href={withBase('safari-pinned-tab.svg')} color="#5bbad5" />
+    <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon} />
+    <link rel="icon" type="image/png" sizes="32x32" href={favicon32} />
+    <link rel="icon" type="image/png" sizes="16x16" href={favicon16} />
+    <link rel="manifest" href={siteManifest} />
+    <link rel="mask-icon" href={safariPinnedTab} color="#5bbad5" />
     <link rel="license" href="https://creativecommons.org/licenses/by-nc/4.0/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -77,53 +119,13 @@ const backgrounds = {
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Russo+One&display=swap"
     />
-    <link rel="stylesheet" href={resolveAssetPath('assets/css/bootstrap.min.css')} />
-    <link rel="stylesheet" href={resolveAssetPath('assets/css/font-awesome-pro.min.css')} />
-    <link rel="stylesheet" href={resolveAssetPath('assets/css/flaticon_gerold.css')} />
-    <link rel="stylesheet" href={resolveAssetPath('assets/css/all.min.css')} />
-    <link rel="stylesheet" href={resolveAssetPath('assets/fonts/bootstrap-icons/font-css.css')} />
-    <link rel="stylesheet" href={resolveAssetPath('assets/fonts/custom-font/css/clash-display.css')} />
-    <style is:inline>
-      .tj-nice-select::after {
-        background-image: url({backgrounds.selectArrow});
-      }
-
-      .theme-banner-three::before {
-        background-image: url({backgrounds.heroBanner});
-      }
-
-      .feature-style-five::before {
-        background-image: url({backgrounds.featureShape});
-      }
-
-      .author-blockquote::before {
-        background-image: url({backgrounds.authorQuote});
-      }
-
-      .project-info {
-        background-image: url({backgrounds.projectInfo});
-      }
-
-      .video-wrapper {
-        background-image: url({backgrounds.videoPrimary});
-      }
-
-      .techy-video {
-        background-image: url({backgrounds.videoSecondary});
-      }
-
-      .bg-wrapper-one {
-        background-image: url({backgrounds.priceBackground});
-      }
-
-      .plan::before {
-        background-image: url({backgrounds.planShape});
-      }
-
-      .error-page-bg {
-        background-image: url({backgrounds.errorSpiral});
-      }
-    </style>
+    <link rel="stylesheet" href={resolvePublicAsset('assets/css/bootstrap.min.css')} />
+    <link rel="stylesheet" href={resolvePublicAsset('assets/css/font-awesome-pro.min.css')} />
+    <link rel="stylesheet" href={resolvePublicAsset('assets/css/flaticon_gerold.css')} />
+    <link rel="stylesheet" href={resolvePublicAsset('assets/css/all.min.css')} />
+    <link rel="stylesheet" href={resolvePublicAsset('assets/fonts/bootstrap-icons/font-css.css')} />
+    <link rel="stylesheet" href={resolvePublicAsset('assets/fonts/custom-font/css/clash-display.css')} />
+    <style is:inline set:html={backgroundStyles} />
     {seoTags && (
       <>
         <title>{seoTags.title}</title>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -7,7 +7,7 @@ import {
   testimonialPortraits,
   iconImages,
 } from '../../data/media';
-import { resolveAssetPath, withBase } from '../../utils/paths';
+import { prependForwardSlash, withBase } from '../../utils/paths';
 import type { SeoInput } from '../../utils/seo';
 import '../../styles/landing/motion.css';
 import '../../styles/landing/hero.css';
@@ -33,7 +33,7 @@ const seo: SeoInput = {
   ],
 };
 
-const asset = resolveAssetPath;
+const asset = (path: string) => withBase(prependForwardSlash(path));
 ---
 
 <Base lang="en" seo={seo}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import {
   testimonialPortraits,
   iconImages,
 } from '../data/media';
-import { resolveAssetPath, withBase } from '../utils/paths';
+import { prependForwardSlash, withBase } from '../utils/paths';
 import type { SeoInput } from '../utils/seo';
 import '../styles/landing/motion.css';
 import '../styles/landing/hero.css';
@@ -36,7 +36,7 @@ const seo: SeoInput = {
   ],
 };
 
-const asset = resolveAssetPath;
+const asset = (path: string) => withBase(prependForwardSlash(path));
 ---
 
 <Base seo={seo}>

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -33,7 +33,5 @@ export const resolveHref = (href: string | undefined, options: { external?: bool
   return withBase(prependForwardSlash(href));
 };
 
-export const resolveAssetPath = (path: string) => withBase(prependForwardSlash(path));
-
 export const isExternalHref = (href: string | undefined) =>
   typeof href === 'string' && isExternalLike(href);

--- a/src/utils/publicAssets.ts
+++ b/src/utils/publicAssets.ts
@@ -1,0 +1,21 @@
+import { prependForwardSlash, withBase } from './paths';
+
+const publicDir = new URL('../../public/', import.meta.url);
+
+const toPublicRelativePath = (url: URL) => {
+  const { pathname } = url;
+  const basePath = publicDir.pathname;
+
+  if (!pathname.startsWith(basePath)) {
+    throw new Error(`Asset ${pathname} is not inside the public directory.`);
+  }
+
+  return pathname.slice(basePath.length);
+};
+
+export const resolvePublicAsset = (pathOrUrl: string | URL) => {
+  const relativePath =
+    typeof pathOrUrl === 'string' ? pathOrUrl : toPublicRelativePath(pathOrUrl);
+
+  return withBase(prependForwardSlash(relativePath));
+};


### PR DESCRIPTION
## Summary
- add a helper to resolve public assets against the configured base path
- update layout, footer, navigation, and responsive image handling to use the helper and URL-based asset references
- normalize navigation slugs and responsive media data so asset URLs remain base-aware across pages

## Testing
- `npm run build`
- `GITHUB_ACTIONS=true GITHUB_REPOSITORY=foo/personal npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d26dc38d10832e8dc9fc04a83b296b