### PR TITLE
Support base-prefixed navigation and assets

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,8 @@
 ---
 import type { Locale } from '../data/navigation';
+import { buildLocalePath } from '../data/navigation';
 import { socialLinks } from '../data/socials';
-import { prependForwardSlash, withBase } from '../utils/paths';
+import { isExternalHref, prependForwardSlash, withBase } from '../utils/paths';
 import { resolvePublicAsset } from '../utils/publicAssets';
 import '../styles/components/footer.css';
 
@@ -35,7 +36,7 @@ const content = {
       'Potion is a newsletter that brings you the most important news from the world of SEO, AI, and marketing every 14 days – concisely, practically, and without fluff.',
     ctaHref: 'https://www.potion.cz',
     ctaLabel: 'Potion Newsletter',
-    privacyHref: 'en/processing-of-personal-data',
+    privacyHref: 'processing-of-personal-data',
     privacyLabel: 'Privacy Policy',
     copyright:
       '© 2025 Martin Bangho<br />SEO Consultant & AI Strategist',
@@ -53,7 +54,25 @@ const content = {
 }>;
 
 const localeContent = content[lang];
-const privacyHref = withBase(prependForwardSlash(localeContent.privacyHref));
+const privacyHref = (() => {
+  const { privacyHref } = localeContent;
+
+  if (!privacyHref) {
+    return withBase('');
+  }
+
+  if (isExternalHref(privacyHref)) {
+    return privacyHref;
+  }
+
+  const localePath = buildLocalePath(lang, privacyHref);
+
+  if (!localePath) {
+    return withBase('');
+  }
+
+  return withBase(prependForwardSlash(localePath));
+})();
 const [
   footerShape1,
   footerShape2,
@@ -68,7 +87,7 @@ const [
   'sluzby/img/shape/star-5b.svg',
   'sluzby/img/shape/star-5b.svg',
   'sluzby/img/shape/line-round-7b.svg',
-].map(resolvePublicAsset);
+].map((path) => resolvePublicAsset(new URL(`../../public/${path}`, import.meta.url)));
 ---
 <footer class="footer-area theme-footer-three pt-145 pt-lg-100 pt-sm-100">
   <img class="footer-shape shape-1b" src={footerShape1} alt="shape" />

--- a/src/components/MainNav.astro
+++ b/src/components/MainNav.astro
@@ -1,6 +1,6 @@
 ---
 import type { Locale } from '../data/navigation';
-import { getNavigation } from '../data/navigation';
+import { buildLocalePath, getNavigation } from '../data/navigation';
 import {
   isExternalHref,
   prependForwardSlash,
@@ -24,17 +24,36 @@ const {
 const navigation = getNavigation(lang);
 const resolveNavigationHref = (
   href: string | undefined,
-  external?: boolean,
+  options: { external?: boolean; locale?: Locale } = {},
 ) => {
-  if (!href) {
+  if (href === undefined) {
     return undefined;
   }
+
+  const { external = false, locale = lang } = options;
 
   if (external || isExternalHref(href)) {
     return href;
   }
 
-  return withBase(prependForwardSlash(href));
+  if (href.startsWith('#')) {
+    const baseSlug = buildLocalePath(locale);
+    if (!baseSlug) {
+      return href;
+    }
+
+    const baseHref = withBase(prependForwardSlash(baseSlug));
+    const normalizedBase = baseHref.endsWith('/') ? baseHref : `${baseHref}/`;
+    return `${normalizedBase}${href}`;
+  }
+
+  const localePath = buildLocalePath(locale, href);
+
+  if (!localePath) {
+    return withBase('');
+  }
+
+  return withBase(prependForwardSlash(localePath));
 };
 
 const logoHref = resolveNavigationHref(navigation.logoHref) ?? withBase('');
@@ -43,15 +62,15 @@ const logoSrc = resolvePublicAsset(
 );
 const menu = navigation.menu.map((item) => ({
   ...item,
-  href: resolveNavigationHref(item.href, item.external),
+  href: resolveNavigationHref(item.href, { external: item.external }),
   items: item.items?.map((child) => ({
     ...child,
-    href: resolveNavigationHref(child.href, child.external),
+    href: resolveNavigationHref(child.href, { external: child.external }),
   })),
 }));
 const languages = navigation.languages.map((language) => ({
   ...language,
-  href: resolveNavigationHref(language.href),
+  href: resolveNavigationHref(language.href, { locale: language.code }),
   flag: resolvePublicAsset(language.flag),
 }));
 const headerClasses = ['theme-main-menu', 'theme-menu-three', headerClass]

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,5 +1,31 @@
 export type Locale = 'cs' | 'en';
 
+const localePathSegments: Record<Locale, string> = {
+  cs: '',
+  en: 'en',
+};
+
+const normalizeSegment = (value: string) => value.replace(/^\/+/, '').replace(/\/+$/, '');
+
+export const buildLocalePath = (locale: Locale, slug = '') => {
+  const prefix = normalizeSegment(localePathSegments[locale] ?? '');
+  const normalizedSlug = slug.replace(/^\/+/, '');
+
+  if (!prefix && !normalizedSlug) {
+    return '';
+  }
+
+  if (!prefix) {
+    return normalizedSlug;
+  }
+
+  if (!normalizedSlug) {
+    return `${prefix}/`;
+  }
+
+  return `${prefix}/${normalizedSlug}`;
+};
+
 export interface ContactBox {
   label: string;
   value: string;
@@ -116,7 +142,7 @@ const navigation: Record<Locale, NavigationData> = {
         code: 'en',
         label: 'English',
         shortLabel: 'EN',
-        href: 'en/',
+        href: '',
         flag: flagIcons.en,
         hreflang: 'en',
       },
@@ -124,7 +150,7 @@ const navigation: Record<Locale, NavigationData> = {
     languageButtonLabel: 'CZ',
   },
   en: {
-    logoHref: 'en/',
+    logoHref: '',
     email: 'martin@bangho.cz',
     contactBoxes: [
       {
@@ -152,39 +178,39 @@ const navigation: Record<Locale, NavigationData> = {
       {
         label: 'SEO Services',
         items: [
-          { label: 'SEO Audit', href: 'en/services/seo-audit' },
-          { label: 'Website Structure', href: 'en/services/website-structure' },
-          { label: 'Website Redesign', href: 'en/services/seo-redesign' },
-          { label: 'Keyword Analysis', href: 'en/services/keyword-analysis' },
-          { label: 'Technical SEO Audit', href: 'en/services/technical-seo-audit' },
-          { label: 'Online PR & Linkbuilding', href: 'en/services/online-pr-linkbuilding' },
-          { label: 'Competitor Analysis', href: 'en/services/competitor-analysis' },
-          { label: 'Continuous SEO', href: 'en/services/continuous-seo' },
-          { label: 'SEO Workshops', href: 'en/services/seo-workshops' },
+          { label: 'SEO Audit', href: 'services/seo-audit' },
+          { label: 'Website Structure', href: 'services/website-structure' },
+          { label: 'Website Redesign', href: 'services/seo-redesign' },
+          { label: 'Keyword Analysis', href: 'services/keyword-analysis' },
+          { label: 'Technical SEO Audit', href: 'services/technical-seo-audit' },
+          { label: 'Online PR & Linkbuilding', href: 'services/online-pr-linkbuilding' },
+          { label: 'Competitor Analysis', href: 'services/competitor-analysis' },
+          { label: 'Continuous SEO', href: 'services/continuous-seo' },
+          { label: 'SEO Workshops', href: 'services/seo-workshops' },
         ],
       },
       {
         label: 'Marketing',
         items: [
-          { label: 'Marketing Strategy', href: 'en/services/marketing-strategy' },
-          { label: 'Content Strategy', href: 'en/services/content-strategy' },
-          { label: 'Copywriting', href: 'en/services/copywriting' },
-          { label: 'Support for Startups', href: 'en/services/support-for-startups' },
-          { label: 'Marketing Workshops', href: 'en/services/marketing-workshops' },
+          { label: 'Marketing Strategy', href: 'services/marketing-strategy' },
+          { label: 'Content Strategy', href: 'services/content-strategy' },
+          { label: 'Copywriting', href: 'services/copywriting' },
+          { label: 'Support for Startups', href: 'services/support-for-startups' },
+          { label: 'Marketing Workshops', href: 'services/marketing-workshops' },
         ],
       },
       {
         label: 'AI for Businesses',
         items: [
-          { label: 'LLM Optimization', href: 'en/services/llm-optimization-geo' },
-          { label: 'AI Consulting', href: 'en/services/ai-consulting' },
-          { label: 'AI Agents & Automation', href: 'en/services/ai-agents-and-automation' },
-          { label: 'AI Workshop', href: 'en/services/ai-workshop' },
+          { label: 'LLM Optimization', href: 'services/llm-optimization-geo' },
+          { label: 'AI Consulting', href: 'services/ai-consulting' },
+          { label: 'AI Agents & Automation', href: 'services/ai-agents-and-automation' },
+          { label: 'AI Workshop', href: 'services/ai-workshop' },
         ],
       },
-      { label: 'Case Studies', href: 'en/#works-section' },
+      { label: 'Case Studies', href: '#works-section' },
       { label: 'Blog', href: 'https://blog.bangho.cz/', external: true },
-      { label: 'Contact', href: 'en/#contact-section' },
+      { label: 'Contact', href: '#contact-section' },
     ],
     languages: [
       {
@@ -199,7 +225,7 @@ const navigation: Record<Locale, NavigationData> = {
         code: 'en',
         label: 'English',
         shortLabel: 'EN',
-        href: 'en/',
+        href: '',
         flag: flagIcons.en,
         hreflang: 'en',
       },

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@ import Footer from '../components/Footer.astro';
 import type { Locale } from '../data/navigation';
 import type { SeoInput } from '../utils/seo';
 import { buildSeoTags } from '../utils/seo';
+import { withBase } from '../utils/paths';
 import { resolvePublicAsset } from '../utils/publicAssets';
 import '../styles/tokens.css';
 import '../styles/base.css';
@@ -25,10 +26,10 @@ const {
 const seoTags = seo ? buildSeoTags(lang, seo) : null;
 const shouldRegisterSw = import.meta.env.PROD;
 
-const serviceWorkerPath = withBase('/sw.js');
+const serviceWorkerPath = resolvePublicAsset(
+  new URL('../../public/sw.js', import.meta.url),
+);
 const serviceWorkerScope = withBase();
-=======
-const serviceWorkerPath = resolvePublicAsset('sw.js');
 const appleTouchIcon = resolvePublicAsset(
   new URL('../../public/apple-touch-icon.png', import.meta.url),
 );
@@ -46,17 +47,55 @@ const safariPinnedTab = resolvePublicAsset(
 );
 
 const backgrounds = {
-  selectArrow: resolvePublicAsset('assets/img/icons/down-arrow.svg'),
-  heroBanner: resolvePublicAsset('assets/img/hero/hero-bg-shap-3a.svg'),
-  featureShape: resolvePublicAsset('sluzby/img/shape/topograph-1c.svg'),
-  authorQuote: resolvePublicAsset('assets/img/icon/icon-45.svg'),
-  projectInfo: resolvePublicAsset('assets/img/work/big-img-01.jpg'),
-  videoPrimary: resolvePublicAsset('assets/img/video/video-1b.jpg'),
-  videoSecondary: resolvePublicAsset('assets/img/video/video-2d.jpg'),
-  priceBackground: resolvePublicAsset('img/bg/price-bg-1c.svg'),
-  planShape: resolvePublicAsset('sluzby/img/shape/topograph-2c.svg'),
-  errorSpiral: resolvePublicAsset('sluzby/img/shape/spiral-1e.svg'),
+  selectArrow: resolvePublicAsset(
+    new URL('../../public/assets/img/icons/down-arrow.svg', import.meta.url),
+  ),
+  heroBanner: resolvePublicAsset(
+    new URL('../../public/assets/img/hero/hero-bg-shap-3a.svg', import.meta.url),
+  ),
+  featureShape: resolvePublicAsset(
+    new URL('../../public/sluzby/img/shape/topograph-1c.svg', import.meta.url),
+  ),
+  authorQuote: resolvePublicAsset(
+    new URL('../../public/assets/img/icon/icon-45.svg', import.meta.url),
+  ),
+  projectInfo: resolvePublicAsset(
+    new URL('../../public/assets/img/work/big-img-01.jpg', import.meta.url),
+  ),
+  videoPrimary: resolvePublicAsset(
+    new URL('../../public/assets/img/video/video-1b.jpg', import.meta.url),
+  ),
+  videoSecondary: resolvePublicAsset(
+    new URL('../../public/assets/img/video/video-2d.jpg', import.meta.url),
+  ),
+  priceBackground: resolvePublicAsset(
+    new URL('../../public/img/bg/price-bg-1c.svg', import.meta.url),
+  ),
+  planShape: resolvePublicAsset(
+    new URL('../../public/sluzby/img/shape/topograph-2c.svg', import.meta.url),
+  ),
+  errorSpiral: resolvePublicAsset(
+    new URL('../../public/sluzby/img/shape/spiral-1e.svg', import.meta.url),
+  ),
 };
+const bootstrapCss = resolvePublicAsset(
+  new URL('../../public/assets/css/bootstrap.min.css', import.meta.url),
+);
+const fontAwesomeCss = resolvePublicAsset(
+  new URL('../../public/assets/css/font-awesome-pro.min.css', import.meta.url),
+);
+const flaticonCss = resolvePublicAsset(
+  new URL('../../public/assets/css/flaticon_gerold.css', import.meta.url),
+);
+const allCss = resolvePublicAsset(
+  new URL('../../public/assets/css/all.min.css', import.meta.url),
+);
+const bootstrapIconsCss = resolvePublicAsset(
+  new URL('../../public/assets/fonts/bootstrap-icons/font-css.css', import.meta.url),
+);
+const clashDisplayCss = resolvePublicAsset(
+  new URL('../../public/assets/fonts/custom-font/css/clash-display.css', import.meta.url),
+);
 const backgroundStyles = `
   .tj-nice-select::after {
     background-image: url("${backgrounds.selectArrow}");
@@ -124,12 +163,12 @@ const backgroundStyles = `
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Russo+One&display=swap"
     />
-    <link rel="stylesheet" href={resolvePublicAsset('assets/css/bootstrap.min.css')} />
-    <link rel="stylesheet" href={resolvePublicAsset('assets/css/font-awesome-pro.min.css')} />
-    <link rel="stylesheet" href={resolvePublicAsset('assets/css/flaticon_gerold.css')} />
-    <link rel="stylesheet" href={resolvePublicAsset('assets/css/all.min.css')} />
-    <link rel="stylesheet" href={resolvePublicAsset('assets/fonts/bootstrap-icons/font-css.css')} />
-    <link rel="stylesheet" href={resolvePublicAsset('assets/fonts/custom-font/css/clash-display.css')} />
+    <link rel="stylesheet" href={bootstrapCss} />
+    <link rel="stylesheet" href={fontAwesomeCss} />
+    <link rel="stylesheet" href={flaticonCss} />
+    <link rel="stylesheet" href={allCss} />
+    <link rel="stylesheet" href={bootstrapIconsCss} />
+    <link rel="stylesheet" href={clashDisplayCss} />
     <style is:inline set:html={backgroundStyles} />
     {seoTags && (
       <>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -7,6 +7,7 @@ import {
   testimonialPortraits,
   iconImages,
 } from '../../data/media';
+import { buildLocalePath } from '../../data/navigation';
 import { prependForwardSlash, withBase } from '../../utils/paths';
 import type { SeoInput } from '../../utils/seo';
 import '../../styles/landing/motion.css';
@@ -34,6 +35,10 @@ const seo: SeoInput = {
 };
 
 const asset = (path: string) => withBase(prependForwardSlash(path));
+const localeLink = (slug: string) => {
+  const localePath = buildLocalePath('en', slug);
+  return localePath ? withBase(prependForwardSlash(localePath)) : withBase('');
+};
 ---
 
 <Base lang="en" seo={seo}>
@@ -1188,7 +1193,7 @@ const asset = (path: string) => withBase(prependForwardSlash(path));
                   </p>
                 </div>
                 <a
-                  href={withBase('en/services/marketing-strategy')}
+                  href={localeLink('services/marketing-strategy')}
                   class="btn tj-btn-secondary reveal reveal-left"
                  
                   >Get Complete Marketing</a
@@ -1688,7 +1693,7 @@ const asset = (path: string) => withBase(prependForwardSlash(path));
                   </div>
                   <div class="tj-contact-form">
                     <form
-                      action="/api/contact"
+                      action={withBase('api/contact')}
                       data-contact-form
                       id="contact-form"
                       method="post"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import {
   testimonialPortraits,
   iconImages,
 } from '../data/media';
+import { buildLocalePath } from '../data/navigation';
 import { prependForwardSlash, withBase } from '../utils/paths';
 import type { SeoInput } from '../utils/seo';
 import '../styles/landing/motion.css';
@@ -37,6 +38,10 @@ const seo: SeoInput = {
 };
 
 const asset = (path: string) => withBase(prependForwardSlash(path));
+const localeLink = (slug: string) => {
+  const localePath = buildLocalePath('cs', slug);
+  return localePath ? withBase(prependForwardSlash(localePath)) : withBase('');
+};
 ---
 
 <Base seo={seo}>
@@ -1398,7 +1403,7 @@ const asset = (path: string) => withBase(prependForwardSlash(path));
                   </p>
                 </div>
                 <a
-                  href={withBase('sluzby/marketingova-strategie')}
+                  href={localeLink('sluzby/marketingova-strategie')}
                   class="btn tj-btn-secondary reveal reveal-left"
                  
                   >Chci kompletní marketing</a
@@ -1897,7 +1902,7 @@ const asset = (path: string) => withBase(prependForwardSlash(path));
                   </div>
                   <div class="tj-contact-form">
                     <form
-                      action="/api/contact"
+                      action={withBase('api/contact')}
                       data-contact-form
                       id="contact-form"
                       method="post"

--- a/src/scripts/contact-form.ts
+++ b/src/scripts/contact-form.ts
@@ -1,6 +1,16 @@
 const RECAPTCHA_SITE_KEY = '6LeLuxwrAAAAACS4SwjIa4pBGqOty0K_qNOrtHtI';
 const DEFAULT_ACTION = 'contact';
 
+const BASE_URL = import.meta.env.BASE_URL ?? '/';
+
+const withBasePath = (path: string) => {
+  const normalizedBase = BASE_URL.endsWith('/') ? BASE_URL : `${BASE_URL}/`;
+  const normalizedPath = path.replace(/^\/+/, '');
+  return `${normalizedBase}${normalizedPath}`;
+};
+
+const CONTACT_ENDPOINT = withBasePath('api/contact');
+
 interface ContactFormMessages {
   success: string;
   error: string;
@@ -180,7 +190,7 @@ function extractPayload(form: HTMLFormElement) {
 }
 
 async function sendPayload(payload: Record<string, unknown>): Promise<SubmitResult> {
-  const response = await fetch('/api/contact', {
+  const response = await fetch(CONTACT_ENDPOINT, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -363,6 +373,7 @@ export function initContactForms() {
     }
 
     meta.form.dataset.initialized = 'true';
+    meta.form.action = CONTACT_ENDPOINT;
     meta.form.addEventListener('submit', handleSubmit);
     setStatus(meta, 'idle');
   });

--- a/src/utils/publicAssets.ts
+++ b/src/utils/publicAssets.ts
@@ -14,8 +14,8 @@ const toPublicRelativePath = (url: URL) => {
 };
 
 export const resolvePublicAsset = (pathOrUrl: string | URL) => {
-  const relativePath =
-    typeof pathOrUrl === 'string' ? pathOrUrl : toPublicRelativePath(pathOrUrl);
+  const url = pathOrUrl instanceof URL ? pathOrUrl : new URL(pathOrUrl, publicDir);
+  const relativePath = toPublicRelativePath(url);
 
   return withBase(prependForwardSlash(relativePath));
 };


### PR DESCRIPTION
## Summary
- add a locale-aware `buildLocalePath` helper and update navigation data to store slugs instead of prefixed URLs
- resolve internal links and footer privacy URL with the new helper so they remain valid when a site base is configured
- ensure all public assets and contact form endpoints are derived from the deployment base, including the front-end script

## Testing
- GITHUB_ACTIONS=true GITHUB_REPOSITORY=owner/personal_web npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2fb3abf50832ea2967de398172563