### PR TITLE
Add CI workflow with Lighthouse performance audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - work
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Test
+        run: npm test --if-present
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.12.0 autorun --config=.lighthouserc.json
+
+      - name: Summarise Lighthouse scores
+        if: always()
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+          const manifestPath = path.join('.lighthouseci', 'manifest.json');
+
+          if (!summaryFile || !fs.existsSync(manifestPath)) {
+            console.warn('No Lighthouse manifest found, skipping summary.');
+            process.exit(0);
+          }
+
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+          if (!Array.isArray(manifest) || manifest.length === 0) {
+            console.warn('Lighthouse manifest empty, skipping summary.');
+            process.exit(0);
+          }
+
+          const header = '| URL | Performance | Accessibility | Best Practices | SEO |';
+          const divider = '| --- | --- | --- | --- | --- |';
+          const rows = manifest.map((run) => {
+            const summary = run.summary || {};
+            const toScore = (metric) => {
+              if (typeof summary[metric] !== 'number') return 'n/a';
+              return `${Math.round(summary[metric] * 100)}`;
+            };
+
+            return `| ${run.url} | ${toScore('performance')} | ${toScore('accessibility')} | ${toScore('bestPractices')} | ${toScore('seo')} |`;
+          });
+
+          const output = ['## Lighthouse results', '', header, divider, ...rows, ''].join('\n');
+          fs.appendFileSync(summaryFile, `${output}\n`);
+          NODE
+
+      - name: Upload Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci
+          if-no-files-found: ignore

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,23 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "url": [
+        "/index.html",
+        "/sluzby/seo-audit/index.html"
+      ],
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.75 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -58,6 +58,11 @@ This document introduces the structure of the `personal_web` project so a new co
 3. Visit the printed localhost URL to browse the site. Astro supports hot-module reloading for components, styles and Markdown content.
 4. Build a production bundle with `npm run build`; preview the result via `npm run preview`.
 
+## Continuous integration
+- Pull requests and pushes trigger the `CI` workflow defined in `.github/workflows/ci.yml`. The job installs dependencies with `npm ci`, runs any available lint or unit test scripts, builds the production bundle and audits the generated output with Lighthouse CI (home page and a representative service detail page).
+- Lighthouse scores are exported to the workflow summary and the full HTML reports are uploaded as build artifacts so reviewers can inspect them without re-running the audit locally.
+- Mark the `CI` workflow status as **required** in the repository settings before deploying so regressions in build, tests or performance metrics block merges.
+
 
 ## Suggested next steps for new contributors
 - Read `docs/interactions.md` to understand the philosophy behind the JavaScript modules and how hydration is controlled.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies, runs lint/tests when present, builds the site and executes a Lighthouse CI audit with uploaded artifacts and job summary
- configure Lighthouse CI to scan the home page and a representative service detail page from the static build output
- document the new CI pipeline and remind maintainers to mark the workflow status as required before deploys

## Testing
- npm run build *(fails: existing syntax error in src/layouts/Base.astro caused by conflict markers already in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fb3ee804832e840b9902ac73b742