### PR TITLE
Fix GitHub Pages asset paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,13 @@ import { defineConfig } from 'astro/config';
 import VitePWA from '@vite-pwa/astro';
 
 const buildHash = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) ?? Date.now().toString(36);
+const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1];
+const isGitHubPages = process.env.GITHUB_ACTIONS === 'true' && Boolean(repoName);
+const site = process.env.SITE ?? 'https://bangho.cz';
 
 export default defineConfig({
+  site,
+  base: isGitHubPages ? `/${repoName}` : '/',
   output: 'static',
   integrations: [
     VitePWA({

--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -1,0 +1,73 @@
+# Codebase Overview
+
+This document introduces the structure of the `personal_web` project so a new contributor can orient themselves quickly.
+
+## Technology stack
+
+- **Astro 4** – static-first site generator used for every page under `src/pages`. Server rendering is only added where needed (for example the contact API route).
+- **Astro Content Collections** – services are stored as Markdown pairs in `src/content/services` and validated by the schema in `src/content/config.ts`.
+- **TypeScript utilities** – helper functions under `src/utils` centralise SEO metadata, alternate language links and service lookups.
+- **Modular styling** – design tokens and resets live in `src/styles/tokens.css` and `src/styles/base.css`; scoped component styles are organised under `src/styles/components`, `src/styles/landing` and `src/styles/services`.
+- **Progressive enhancement** – small ES modules in `src/scripts` provide optional interactions (navigation, carousels, contact form handling) and are hydrated lazily from the Astro components that require them.
+- **PWA tooling** – the build integrates a local copy of `@vite-pwa/astro` to generate the precache manifest consumed by `public/sw.js`.
+
+## Repository layout
+
+```
+.
+├── docs/                    Additional architecture notes (API, interactions, PWA)
+├── public/                  Static assets served verbatim (icons, legacy fallback pages, service worker)
+├── src/
+│   ├── components/          Reusable Astro components such as navigation, footer and responsive images
+│   ├── content/             Markdown content collections for services (CS/EN pairs)
+│   ├── data/                TypeScript data sources for navigation, social links and media assets
+│   ├── layouts/             Shared page layouts (currently `Base.astro`)
+│   ├── pages/               Route definitions including home pages, service detail pages and API routes
+│   ├── scripts/             TypeScript ES modules providing optional client-side behaviour
+│   ├── styles/              Global tokens/base styles plus component- or page-specific CSS
+│   └── utils/               Helper functions for SEO tags and content collection access
+├── astro.config.mjs         Astro project configuration (site URL, integrations, build output)
+├── package.json             npm scripts and dependencies
+└── tsconfig.json            TypeScript configuration shared by Astro and scripts
+```
+
+### Pages and layouts
+- `src/layouts/Base.astro` wraps every page with the navigation (`MainNav`), footer and shared `<head>` metadata helpers.
+- `src/pages/index.astro` and `src/pages/en/index.astro` are the Czech and English landing pages.
+- Service detail pages are generated from content collections via the Astro endpoints in `src/pages/sluzby/[slug].astro` and `src/pages/en/services/[slug].astro`.
+- `src/pages/api/contact.ts` implements the serverless contact form endpoint backed by the helper described in `docs/contact-api.md`.
+- `src/pages/offline.astro` provides the offline fallback used by the service worker.
+
+### Data & SEO
+- Navigation data (links, CTA buttons, locale switchers) is centralised in `src/data/navigation.ts` and rendered through `src/components/MainNav.astro`.
+- Social links and footer contact details live in `src/data/socials.ts` and are consumed by `src/components/Footer.astro`.
+- SEO helpers in `src/utils/seo.ts` compute canonical URLs, `hreflang` alternates and JSON-LD fragments for every page.
+
+### Styles & scripts
+- Design system tokens (colours, spacing, typography) are defined in `src/styles/tokens.css`.
+- Global resets and base layout rules sit in `src/styles/base.css`.
+- The landing and services directories contain CSS modules that are imported by individual components for scoped styling.
+- Client-side scripts in `src/scripts` are imported with Astro directives such as `client:idle` so that JavaScript only runs when required.
+
+### Legacy assets
+- The `public/` folder still hosts a handful of legacy HTML pages (e.g. legal documents, thank-you pages) and assets. They continue to work because Astro copies them to the final build output. When time allows, consider migrating them into Astro pages so they benefit from the shared layout and data sources.
+
+## Getting started locally
+1. Install dependencies: `npm install`
+2. Start the development server: `npm run dev`
+3. Visit the printed localhost URL to browse the site. Astro supports hot-module reloading for components, styles and Markdown content.
+4. Build a production bundle with `npm run build`; preview the result via `npm run preview`.
+
+## Deployment
+- Continuous delivery is handled by `.github/workflows/deploy.yml`. The workflow builds the site on every push to `main` (or on manual runs) and publishes the output to the `gh-pages` branch via GitHub Pages.
+- No additional configuration is required for local preview builds. When the workflow runs inside GitHub Actions it automatically sets the correct base path for project pages, so assets resolve from `/<repository-name>/`.
+- To deploy to a different domain, override the `SITE` environment variable during the build so generated canonical URLs reflect the production hostname.
+
+## Suggested next steps for new contributors
+- Read `docs/interactions.md` to understand the philosophy behind the JavaScript modules and how hydration is controlled.
+- Study `docs/contact-api.md` before touching the serverless form handler or environment secrets.
+- Review `docs/pwa.md` when modifying the service worker or cache configuration.
+- Familiarise yourself with Astro Content Collections by browsing `src/content/services` and the associated utilities in `src/utils/services.ts`.
+- When adding new sections or services, keep Czech and English content aligned by creating paired Markdown entries and extending the navigation data.
+
+Happy building!

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import type { Locale } from '../data/navigation';
 import { socialLinks } from '../data/socials';
+import { resolvePath } from '../utils/paths';
 import '../styles/components/footer.css';
 
 interface Props {
@@ -51,14 +52,22 @@ const content = {
 }>;
 
 const localeContent = content[lang];
+const footerShapes = {
+  star1: resolvePath('/sluzby/img/shape/star-3b.svg'),
+  star2: resolvePath('/sluzby/img/shape/star-4b.svg'),
+  star3: resolvePath('/sluzby/img/shape/star-6b.svg'),
+  star4: resolvePath('/sluzby/img/shape/star-5b.svg'),
+  star5: resolvePath('/sluzby/img/shape/star-5b.svg'),
+  line: resolvePath('/sluzby/img/shape/line-round-7b.svg'),
+};
 ---
 <footer class="footer-area theme-footer-three pt-145 pt-lg-100 pt-sm-100">
-  <img class="footer-shape shape-1b" src="/sluzby/img/shape/star-3b.svg" alt="shape" />
-  <img class="footer-shape shape-2b" src="/sluzby/img/shape/star-4b.svg" alt="shape" />
-  <img class="footer-shape shape-3b" src="/sluzby/img/shape/star-6b.svg" alt="shape" />
-  <img class="footer-shape shape-4b" src="/sluzby/img/shape/star-5b.svg" alt="shape" />
-  <img class="footer-shape shape-5b" src="/sluzby/img/shape/star-5b.svg" alt="shape" />
-  <img class="fot-shape-one" src="/sluzby/img/shape/line-round-7b.svg" alt="footer shape" />
+  <img class="footer-shape shape-1b" src={footerShapes.star1} alt="shape" />
+  <img class="footer-shape shape-2b" src={footerShapes.star2} alt="shape" />
+  <img class="footer-shape shape-3b" src={footerShapes.star3} alt="shape" />
+  <img class="footer-shape shape-4b" src={footerShapes.star4} alt="shape" />
+  <img class="footer-shape shape-5b" src={footerShapes.star5} alt="shape" />
+  <img class="fot-shape-one" src={footerShapes.line} alt="footer shape" />
   <div class="container">
     <div class="row gx-4 gx-xxl-5 mb-10">
       <div class="col-xxl-1 col-md-1"></div>
@@ -97,7 +106,7 @@ const localeContent = content[lang];
         <div class="col-xl-4 col-lg-4 pb-30">
           <ul class="fot-list text-center d-sm-flex align-items-center justify-content-center justify-content-lg-start">
             <li>
-              <a href={localeContent.privacyHref}>{localeContent.privacyLabel}</a>
+              <a href={resolvePath(localeContent.privacyHref)}>{localeContent.privacyLabel}</a>
             </li>
           </ul>
         </div>

--- a/src/components/MainNav.astro
+++ b/src/components/MainNav.astro
@@ -1,6 +1,7 @@
 ---
 import type { Locale } from '../data/navigation';
 import { getNavigation } from '../data/navigation';
+import { resolvePath } from '../utils/paths';
 import '../styles/components/navigation.css';
 
 interface Props {
@@ -29,6 +30,7 @@ const externalAttrs = {
   target: '_blank',
   rel: 'noreferrer',
 };
+const logoSrc = resolvePath('/assets/img/logo.ico');
 ---
 <header class={headerClasses}>
   <div class={topHeaderClasses}>
@@ -39,7 +41,7 @@ const externalAttrs = {
             <div>
               <a href={navigation.logoHref}>
                 <img
-                  src="/assets/img/logo.ico"
+                  src={logoSrc}
                   alt="Logo Martin Bangho"
                   width="60"
                   height="60"
@@ -193,7 +195,7 @@ const externalAttrs = {
   </div>
   <div class="mobile-header px-1 py-2 d-flex align-items-center">
     <a href={navigation.logoHref} class="d-flex align-items-center text-white text-decoration-none">
-      <img src="/assets/img/logo.ico" alt="Logo" width="46" height="46" class="me-2" />
+      <img src={logoSrc} alt="Logo" width="46" height="46" class="me-2" />
     </a>
     <span class="mobile-email">{navigation.email}</span>
   </div>

--- a/src/data/media.ts
+++ b/src/data/media.ts
@@ -1,4 +1,5 @@
 import type { ResponsiveImageProps, ResponsiveSource } from '../components/ResponsiveImage.astro';
+import { resolvePath } from '../utils/paths';
 
 export type ImageSource = ResponsiveSource;
 
@@ -11,41 +12,43 @@ type ImageMap = Record<string, ImageMetadata>;
 
 type GalleryMap = Record<string, ImageMetadata[]>;
 
+const asset = (path: string) => resolvePath(path) ?? path;
+
 export const heroPortrait: ImageMetadata = {
-  src: '/assets/img/hero/me.png',
+  src: asset('/assets/img/hero/me.png'),
   width: 1920,
   height: 1920,
   sources: [
     {
       type: 'image/webp',
-      srcset: '/assets/img/hero/me.webp',
+      srcset: asset('/assets/img/hero/me.webp'),
     },
   ],
 };
 
 export const testimonialPortraits: ImageMap = {
   kejval: {
-    src: '/assets/img/testimonials/user/kejval.jpg',
+    src: asset('/assets/img/testimonials/user/kejval.jpg'),
     width: 491,
     height: 491,
   },
   zatkovic: {
-    src: '/assets/img/testimonials/user/zatkovic.webp',
+    src: asset('/assets/img/testimonials/user/zatkovic.webp'),
     width: 1365,
     height: 1365,
   },
   vlcek: {
-    src: '/assets/img/testimonials/user/vlcek.jpg',
+    src: asset('/assets/img/testimonials/user/vlcek.jpg'),
     width: 1310,
     height: 1310,
   },
   kapic: {
-    src: '/assets/img/testimonials/user/kapic.jpg',
+    src: asset('/assets/img/testimonials/user/kapic.jpg'),
     width: 1638,
     height: 1638,
   },
   architekti: {
-    src: '/assets/img/testimonials/user/architekti.jpg',
+    src: asset('/assets/img/testimonials/user/architekti.jpg'),
     width: 300,
     height: 300,
   },
@@ -54,61 +57,61 @@ export const testimonialPortraits: ImageMap = {
 export const portfolioGalleryImages: GalleryMap = {
   o2: [
     {
-      src: '/assets/img/portfolio-gallery/o2_2.png',
+      src: asset('/assets/img/portfolio-gallery/o2_2.png'),
       width: 1119,
       height: 560,
     },
     {
-      src: '/assets/img/portfolio-gallery/o2_3.png',
+      src: asset('/assets/img/portfolio-gallery/o2_3.png'),
       width: 1114,
       height: 557,
     },
     {
-      src: '/assets/img/portfolio-gallery/o2_4.png',
+      src: asset('/assets/img/portfolio-gallery/o2_4.png'),
       width: 1114,
       height: 557,
     },
     {
-      src: '/assets/img/portfolio-gallery/o2_5.png',
+      src: asset('/assets/img/portfolio-gallery/o2_5.png'),
       width: 600,
       height: 300,
     },
   ],
   sofa: [
     {
-      src: '/assets/img/portfolio-gallery/sofa_2.png',
+      src: asset('/assets/img/portfolio-gallery/sofa_2.png'),
       width: 1617,
       height: 808,
     },
     {
-      src: '/assets/img/portfolio-gallery/sofa_3.png',
+      src: asset('/assets/img/portfolio-gallery/sofa_3.png'),
       width: 1699,
       height: 850,
     },
     {
-      src: '/assets/img/portfolio-gallery/sofa_4.png',
+      src: asset('/assets/img/portfolio-gallery/sofa_4.png'),
       width: 1701,
       height: 850,
     },
     {
-      src: '/assets/img/portfolio-gallery/sofa_5.png',
+      src: asset('/assets/img/portfolio-gallery/sofa_5.png'),
       width: 1703,
       height: 852,
     },
   ],
   security: [
     {
-      src: '/assets/img/portfolio-gallery/avast.png',
+      src: asset('/assets/img/portfolio-gallery/avast.png'),
       width: 1631,
       height: 842,
     },
     {
-      src: '/assets/img/portfolio-gallery/norton.png',
+      src: asset('/assets/img/portfolio-gallery/norton.png'),
       width: 1612,
       height: 833,
     },
     {
-      src: '/assets/img/portfolio-gallery/lifelock.png',
+      src: asset('/assets/img/portfolio-gallery/lifelock.png'),
       width: 1612,
       height: 861,
     },
@@ -117,7 +120,7 @@ export const portfolioGalleryImages: GalleryMap = {
 
 export const iconImages: ImageMap = {
   n8n: {
-    src: '/assets/img/icons/n8n.png',
+    src: asset('/assets/img/icons/n8n.png'),
     width: 500,
     height: 500,
   },

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,3 +1,5 @@
+import { resolvePath } from '../utils/paths';
+
 export type Locale = 'cs' | 'en';
 
 export interface ContactBox {
@@ -203,6 +205,29 @@ const navigation: Record<Locale, NavigationData> = {
   },
 };
 
-export const getNavigation = (lang: Locale = 'cs') => navigation[lang];
+const mapMenuItem = (item: MenuItem): MenuItem => ({
+  ...item,
+  href: resolvePath(item.href) ?? item.href,
+  items: item.items?.map(mapMenuItem),
+});
+
+export const getNavigation = (lang: Locale = 'cs') => {
+  const config = navigation[lang];
+
+  return {
+    ...config,
+    logoHref: resolvePath(config.logoHref) ?? config.logoHref,
+    contactBoxes: config.contactBoxes.map((box) => ({
+      ...box,
+      href: resolvePath(box.href) ?? box.href,
+    })),
+    menu: config.menu.map(mapMenuItem),
+    languages: config.languages.map((language) => ({
+      ...language,
+      href: resolvePath(language.href) ?? language.href,
+      flag: resolvePath(language.flag) ?? language.flag,
+    })),
+    } satisfies NavigationData;
+  };
 
 export type Navigation = typeof navigation;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@ import Footer from '../components/Footer.astro';
 import type { Locale } from '../data/navigation';
 import type { SeoInput } from '../utils/seo';
 import { buildSeoTags } from '../utils/seo';
+import { resolvePath } from '../utils/paths';
 import '../styles/tokens.css';
 import '../styles/base.css';
 
@@ -23,6 +24,18 @@ const {
 
 const seoTags = seo ? buildSeoTags(lang, seo) : null;
 const shouldRegisterSw = import.meta.env.PROD;
+const serviceWorkerPath = resolvePath('/sw.js');
+const cssAssetVars = {
+  '--asset-select-arrow': `url('${resolvePath('/assets/img/icons/down-arrow.svg')}')`,
+  '--asset-hero-shape': `url('${resolvePath('/assets/img/hero/hero-bg-shap-3a.svg')}')`,
+  '--asset-topograph-1c': `url('${resolvePath('/assets/img/shape/topograph-1c.svg')}')`,
+  '--asset-icon-45': `url('${resolvePath('/assets/img/icon/icon-45.svg')}')`,
+  '--asset-work-big-01': `url('${resolvePath('/assets/img/work/big-img-01.jpg')}')`,
+  '--asset-video-1b': `url('${resolvePath('/assets/img/video/video-1b.jpg')}')`,
+  '--asset-video-2d': `url('${resolvePath('/assets/img/video/video-2d.jpg')}')`,
+  '--asset-topograph-2c': `url('${resolvePath('/assets/img/img/shape/topograph-2c.svg')}')`,
+  '--asset-spiral-1e': `url('${resolvePath('/assets/img/shape/spiral-1e.svg')}')`,
+} as const;
 ---
 
 <!DOCTYPE html>
@@ -33,11 +46,25 @@ const shouldRegisterSw = import.meta.env.PROD;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="msapplication-TileColor" content="#9f00a7" />
     <meta name="theme-color" content="#ffffff" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href={resolvePath('/apple-touch-icon.png')}
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href={resolvePath('/favicon-32x32.png')}
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href={resolvePath('/favicon-16x16.png')}
+    />
+    <link rel="manifest" href={resolvePath('/site.webmanifest')} />
+    <link rel="mask-icon" href={resolvePath('/safari-pinned-tab.svg')} color="#5bbad5" />
     <link rel="license" href="https://creativecommons.org/licenses/by-nc/4.0/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -49,12 +76,26 @@ const shouldRegisterSw = import.meta.env.PROD;
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Russo+One&display=swap"
     />
-    <link rel="stylesheet" href="/assets/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="/assets/css/font-awesome-pro.min.css" />
-    <link rel="stylesheet" href="/assets/css/flaticon_gerold.css" />
-    <link rel="stylesheet" href="/assets/css/all.min.css" />
-    <link rel="stylesheet" href="/assets/fonts/bootstrap-icons/font-css.css" />
-    <link rel="stylesheet" href="/assets/fonts/custom-font/css/clash-display.css" />
+    <link rel="stylesheet" href={resolvePath('/assets/css/bootstrap.min.css')} />
+    <link
+      rel="stylesheet"
+      href={resolvePath('/assets/css/font-awesome-pro.min.css')}
+    />
+    <link rel="stylesheet" href={resolvePath('/assets/css/flaticon_gerold.css')} />
+    <link rel="stylesheet" href={resolvePath('/assets/css/all.min.css')} />
+    <link
+      rel="stylesheet"
+      href={resolvePath('/assets/fonts/bootstrap-icons/font-css.css')}
+    />
+    <link
+      rel="stylesheet"
+      href={resolvePath('/assets/fonts/custom-font/css/clash-display.css')}
+    />
+    <style is:inline>
+      {`:root {\n${Object.entries(cssAssetVars)
+        .map(([name, value]) => `  ${name}: ${value};`)
+        .join('\n')}\n}`}
+    </style>
     {seoTags && (
       <>
         <title>{seoTags.title}</title>
@@ -133,7 +174,7 @@ gtag('config', 'G-92X11QBKZL');`}
       <script>
         {`if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((error) => {
+    navigator.serviceWorker.register('${serviceWorkerPath}').catch((error) => {
       console.error('Service worker registration failed', error);
     });
   });

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -8,6 +8,7 @@ import {
   iconImages,
 } from '../../data/media';
 import type { SeoInput } from '../../utils/seo';
+import { resolvePath } from '../../utils/paths';
 import '../../styles/landing/motion.css';
 import '../../styles/landing/hero.css';
 import '../../styles/landing/services.css';
@@ -31,6 +32,7 @@ const seo: SeoInput = {
     { href: 'https://bangho.cz/en/', hreflang: 'x-default' },
   ],
 };
+const withBase = (path: string) => resolvePath(path) ?? path;
 ---
 
 <Base lang="en" seo={seo}>
@@ -606,7 +608,7 @@ const seo: SeoInput = {
 
                               <div class="portfolio-item">
                                   <div class="image-box">
-                                      <img src="/assets/img/portfolio/O2-Logo.svg" alt="" />
+                                      <img src={withBase('/assets/img/portfolio/O2-Logo.svg')} alt="" />
                                   </div>
                                   <div class="content-box">
                                       <h3 class="portfolio-title">O2 Czech Republic</h3>
@@ -617,7 +619,7 @@ const seo: SeoInput = {
                               </div>
                               <div class="portfolio-item">
                                   <div class="image-box">
-                                      <img src="/assets/img/portfolio/Gen_logo.svg" alt="" />
+                                      <img src={withBase('/assets/img/portfolio/Gen_logo.svg')} alt="" />
                                   </div>
                                   <div class="content-box">
                                       <h3 class="portfolio-title">Gen Digital Inc.</h3>
@@ -639,7 +641,7 @@ const seo: SeoInput = {
                               <div class="skill-item reveal reveal-up">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="/assets/img/portfolio/angry.svg" alt="" />
+                                          <img src={withBase('/assets/img/portfolio/angry.svg')} alt="" />
                                       </div>
                                       <div class="number">Angry Beards</div>
                                   </div>
@@ -647,7 +649,7 @@ const seo: SeoInput = {
                               <div class="skill-item reveal reveal-up">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="/assets/img/portfolio/srovname.svg" alt="" />
+                                          <img src={withBase('/assets/img/portfolio/srovname.svg')} alt="" />
                                       </div>
                                       <div class="number">Srovnáme</div>
                                   </div>
@@ -655,7 +657,7 @@ const seo: SeoInput = {
                               <div class="skill-item reveal reveal-up">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="/assets/img/portfolio/avast.svg" alt="" />
+                                          <img src={withBase('/assets/img/portfolio/avast.svg')} alt="" />
                                       </div>
                                       <div class="number">Avast</div>
                                   </div>
@@ -663,7 +665,7 @@ const seo: SeoInput = {
                               <div class="skill-item reveal reveal-up">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="/assets/img/portfolio/norton.svg" alt="" />
+                                          <img src={withBase('/assets/img/portfolio/norton.svg')} alt="" />
                                       </div>
                                       <div class="number">Norton</div>
                                   </div>
@@ -671,7 +673,7 @@ const seo: SeoInput = {
                               <div class="skill-item reveal reveal-up">
                                   <div class="skill-inner">
                                       <div class="icon-box">
-                                          <img src="/assets/img/portfolio/cockyna.svg" alt="" />
+                                          <img src={withBase('/assets/img/portfolio/cockyna.svg')} alt="" />
                                       </div>
                                       <div class="number">Čočkýna</div>
                                   </div>
@@ -1079,7 +1081,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/scf.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/scf.svg')} alt="" />
                       </div>
                       <div class="number">Screaming Frog</div>
                     </div>
@@ -1087,7 +1089,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/Ahrefs.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/Ahrefs.svg')} alt="" />
                       </div>
                       <div class="number">Ahrefs<br /></div>
                     </div>
@@ -1096,7 +1098,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/gsc.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/gsc.svg')} alt="" />
                       </div>
                       <div class="number">Search Console</div>
                     </div>
@@ -1104,7 +1106,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/ga.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/ga.svg')} alt="" />
                       </div>
                       <div class="number">Google Analytics</div>
                     </div>
@@ -1112,7 +1114,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/looker.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/looker.svg')} alt="" />
                       </div>
                       <div class="number">Data Analytics</div>
                     </div>
@@ -1120,7 +1122,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/wp.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/wp.svg')} alt="" />
                       </div>
                       <div class="number">CMS<br />Systems</div>
                     </div>
@@ -1128,7 +1130,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/html.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/html.svg')} alt="" />
                       </div>
                       <div class="number">Web &<br />Development</div>
                     </div>
@@ -1136,7 +1138,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/chatgpt.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/chatgpt.svg')} alt="" />
                       </div>
                       <div class="number">AI Tools<br />& LLMs</div>
                     </div>
@@ -1155,7 +1157,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/jira.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/jira.svg')} alt="" />
                       </div>
                       <div class="number">Project Management</div>
                     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import {
   iconImages,
 } from '../data/media';
 import type { SeoInput } from '../utils/seo';
+import { resolvePath } from '../utils/paths';
 import '../styles/landing/motion.css';
 import '../styles/landing/hero.css';
 import '../styles/landing/services.css';
@@ -34,6 +35,7 @@ const seo: SeoInput = {
     { href: 'https://bangho.cz/en', hreflang: 'x-default' },
   ],
 };
+const withBase = (path: string) => resolvePath(path) ?? path;
 ---
 
 <Base seo={seo}>
@@ -709,7 +711,7 @@ const seo: SeoInput = {
 
                   <div class="portfolio-item">
                     <div class="image-box">
-                      <img src="/assets/img/portfolio/O2-Logo.svg" alt="" />
+                      <img src={withBase('/assets/img/portfolio/O2-Logo.svg')} alt="" />
                     </div>
                     <div class="content-box">
                       <h3 class="portfolio-title">O2 Czech Republic</h3>
@@ -723,7 +725,7 @@ const seo: SeoInput = {
                   </div>
                   <div class="portfolio-item">
                     <div class="image-box">
-                      <img src="/assets/img/portfolio/Gen_logo.svg" alt="" />
+                      <img src={withBase('/assets/img/portfolio/Gen_logo.svg')} alt="" />
                     </div>
                     <div class="content-box">
                       <h3 class="portfolio-title">Gen Digital Inc.</h3>
@@ -748,7 +750,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/portfolio/angry.svg" alt="" />
+                        <img src={withBase('/assets/img/portfolio/angry.svg')} alt="" />
                       </div>
                       <div class="number">Angry Beards</div>
                     </div>
@@ -756,7 +758,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/portfolio/srovname.svg" alt="" />
+                        <img src={withBase('/assets/img/portfolio/srovname.svg')} alt="" />
                       </div>
                       <div class="number">Srovnáme</div>
                     </div>
@@ -764,7 +766,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/portfolio/avast.svg" alt="" />
+                        <img src={withBase('/assets/img/portfolio/avast.svg')} alt="" />
                       </div>
                       <div class="number">Avast</div>
                     </div>
@@ -772,7 +774,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/portfolio/norton.svg" alt="" />
+                        <img src={withBase('/assets/img/portfolio/norton.svg')} alt="" />
                       </div>
                       <div class="number">Norton</div>
                     </div>
@@ -780,7 +782,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/portfolio/cockyna.svg" alt="" />
+                        <img src={withBase('/assets/img/portfolio/cockyna.svg')} alt="" />
                       </div>
                       <div class="number">Čočkýna</div>
                     </div>
@@ -1289,7 +1291,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/scf.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/scf.svg')} alt="" />
                       </div>
                       <div class="number">Screaming Frog</div>
                     </div>
@@ -1297,7 +1299,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/Ahrefs.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/Ahrefs.svg')} alt="" />
                       </div>
                       <div class="number">Ahrefs</div>
                     </div>
@@ -1306,7 +1308,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/gsc.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/gsc.svg')} alt="" />
                       </div>
                       <div class="number">Search Console</div>
                     </div>
@@ -1314,7 +1316,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/ga.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/ga.svg')} alt="" />
                       </div>
                       <div class="number">Google Analytics</div>
                     </div>
@@ -1322,7 +1324,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/looker.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/looker.svg')} alt="" />
                       </div>
                       <div class="number">Datová Analytika</div>
                     </div>
@@ -1330,7 +1332,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/wp.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/wp.svg')} alt="" />
                       </div>
                       <div class="number">CMS<br />Systémy</div>
                     </div>
@@ -1338,7 +1340,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/html.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/html.svg')} alt="" />
                       </div>
                       <div class="number">Web &<br />Vývoj</div>
                     </div>
@@ -1346,7 +1348,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/chatgpt.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/chatgpt.svg')} alt="" />
                       </div>
                       <div class="number">AI nástroje<br />& LLMs</div>
                     </div>
@@ -1365,7 +1367,7 @@ const seo: SeoInput = {
                   <div class="skill-item reveal reveal-up">
                     <div class="skill-inner">
                       <div class="icon-box">
-                        <img src="/assets/img/icons/jira.svg" alt="" />
+                        <img src={withBase('/assets/img/icons/jira.svg')} alt="" />
                       </div>
                       <div class="number">Projektový Management</div>
                     </div>
@@ -1395,9 +1397,9 @@ const seo: SeoInput = {
                   </p>
                 </div>
                 <a
-                  href="/sluzby/marketingova-strategie"
+                  href={withBase('/sluzby/marketingova-strategie')}
                   class="btn tj-btn-secondary reveal reveal-left"
-                 
+
                   >Chci kompletní marketing</a
                 >
               </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -361,7 +361,7 @@ a h6:hover {
 	top: 50%;
 	right: 10px;
 	position: absolute;
-	background: url(/assets/img/icons/down-arrow.svg);
+    background: var(--asset-select-arrow);
 	background-position: center;
 	background-size: cover;
 	border: none;

--- a/src/styles/services/details.css
+++ b/src/styles/services/details.css
@@ -561,7 +561,7 @@
 .theme-banner-three::before {
   content: "";
   position: absolute;
-  background: url(/assets/img/hero/hero-bg-shap-3a.svg) no-repeat;
+  background: var(--asset-hero-shape) no-repeat;
   background-size: cover;
   width: 100%;
   height: 1095px;
@@ -1650,7 +1650,7 @@
 .feature-style-five::before {
   content: "";
   position: absolute;
-  background: url(/assets/img/shape/topograph-1c.svg) no-repeat;
+  background: var(--asset-topograph-1c) no-repeat;
   width: 100%;
   height: 0px;
   left: 0;
@@ -2537,7 +2537,7 @@ ul.slick-dots li.slick-active {
 }
 .author-blockquote::before {
   content: " ";
-  background: url(/assets/img/icon/icon-45.svg) no-repeat;
+  background: var(--asset-icon-45) no-repeat;
   width: 53px;
   height: 40px;
   opacity: 0.3;
@@ -3269,7 +3269,7 @@ ul.slick-dots li.slick-active {
 }
 
 .project-info {
-  background: url(/assets/img/work/big-img-01.jpg) no-repeat;
+  background: var(--asset-work-big-01) no-repeat;
   background-size: cover;
   background-position: center;
 }
@@ -3308,7 +3308,7 @@ ul.slick-dots li.slick-active {
 }
 
 .video-wrapper {
-  background: url(/assets/img/video/video-1b.jpg) no-repeat;
+  background: var(--asset-video-1b) no-repeat;
   width: 100%;
   min-height: 650px;
   background-position: center;
@@ -3335,7 +3335,7 @@ ul.slick-dots li.slick-active {
 }
 
 .techy-video {
-  background: url(/assets/img/video/video-2d.jpg) no-repeat;
+  background: var(--asset-video-2d) no-repeat;
   width: 100%;
   background-size: cover;
   background-position: center;
@@ -4138,7 +4138,7 @@ ul.slick-dots li.slick-active {
 }
 .plan::before {
   content: "";
-  background: url("/assets/img/img/shape/topograph-2c.svg") no-repeat;
+  background: var(--asset-topograph-2c) no-repeat;
   position: absolute;
   left: 11px;
   right: 0;
@@ -5580,7 +5580,7 @@ ul.slick-dots li.slick-active {
 }
 
 .error-page-bg {
-  background: url(/assets/img/shape/spiral-1e.svg) no-repeat;
+  background: var(--asset-spiral-1e) no-repeat;
   background-size: cover;
   background-position: center;
   position: relative;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,32 @@
+const HAS_PROTOCOL = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+const normalizeBase = (base: string) => {
+  if (!base) {
+    return '/';
+  }
+
+  return base.endsWith('/') ? base : `${base}/`;
+};
+
+/**
+ * Prefix a relative path with the configured Astro base URL.
+ * External URLs (http:, https:, mailto:, tel:, etc.) are returned unchanged.
+ */
+export const resolvePath = (path?: string | null): string | undefined => {
+  if (!path) {
+    return path ?? undefined;
+  }
+
+  if (HAS_PROTOCOL.test(path) || path.startsWith('//')) {
+    return path;
+  }
+
+  const base = normalizeBase(import.meta.env.BASE_URL ?? '/');
+
+  if (path.startsWith('#')) {
+    return `${base}${path}`;
+  }
+
+  const normalized = path.startsWith('/') ? path.slice(1) : path;
+  return `${base}${normalized}`;
+};


### PR DESCRIPTION
## Summary
- add a `resolvePath` helper and use it throughout the layout, navigation, footer, and image metadata so public assets respect the configured base path
- inject CSS variables for background imagery and switch landing pages to `withBase(...)` helpers so page images and internal links work under a GitHub Pages prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca702124a8832e987e6c6aabaa445c